### PR TITLE
Juno Display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 deps
+!deps/build.jl
+!deps/build_pytensorflow.jl
 src/scratch.jl
 tfdocs
 docs/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-deps/downloads
-deps/miniconda
+deps
 src/scratch.jl
 tfdocs
 docs/build
-deps/usr

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,9 +1,15 @@
 using Juno
-using Media
+import Juno: Tree, Row, fade, interleave
 
-Media.@render Juno.Inline t::Tensor begin
-    s = sprint(show, t)
-    Text(s)
+@render Juno.Inline t::Tensor begin
+  s = get_shape(t)
+  shape = s.rank_unknown ? [fade("unknown")] :
+    interleave(map(dim -> get(dim, fade("?")), s.dims), fade("×"))
+  Tree(Row(fade(try string(eltype(t)," ") catch e "" end),
+           Juno.span(".constant.support.type", "Tensor "),
+           shape...),
+       [Text("name: $(node_name(t.op))"),
+        Text("index: $(t.value_index)")])
 end
 
 function Base.show(io::IO, s::Status)


### PR DESCRIPTION
Just a suggestion; I can tweak this as needed to show the right information in the right places.

<img width="434" alt="screenshot 2016-09-30 12 24 38" src="https://cloud.githubusercontent.com/assets/2234614/18990416/a03bb096-8709-11e6-9a81-c0d4b42d324e.png">

I also added the `deps` folder to gitignore wholesale because it was showing me download files that didn't need committing – but let me know if that's mistaken.