### PR TITLE
Fix conversion error

### DIFF
--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -214,7 +214,7 @@ register_shape("Reshape") do op
     if isnull(maybe)
         return [TensorShape(nothing)]
     else
-        return [get(maybe)]
+        return [TensorShape(get(maybe))]
     end
 end
 


### PR DESCRIPTION
Prior to this I was getting `no method convert(TensorShape, ::Array{Int32})` coming from line 83, so I guess `shape_inferrer` isn't guaranteed to return a `TensorShape`.

After this I'm still seeing an `invalid Array dimensions` error coming from `get_attr` with shape inference – I'll push a fix if I have one.