### PR TITLE
fix deprecated exp, use exp.(x)

### DIFF
--- a/examples/logistic.jl
+++ b/examples/logistic.jl
@@ -3,7 +3,7 @@ using Distributions
 # Generate some synthetic data
 x = randn(100, 50)
 w = randn(50, 10)
-y_prob = exp(x*w)
+y_prob = exp.(x*w)
 y_prob ./= sum(y_prob,2)
 
 function draw(probs)


### PR DESCRIPTION
Fix the deprecated warning in `examples/logistic.jl`
```
WARNING: exp{T <: Number}(x::AbstractArray{T}) is deprecated, use exp.(x) instead.
```

thanks.