### PR TITLE
Fix Unpack, and refactor to use `get_shape(x, dim)`

### DIFF
--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -117,14 +117,7 @@ function rnn(cell, inputs; initial_state=nothing, dtype=nothing, sequence_length
         if dtype === nothing
             error("dtype must be set if initial_state is not provided")
         end
-        shape = get_shape(inputs[1])
-        if shape.rank_unknown
-            error("Shape of input is unknown")
-        end
-        if isnull(shape.dims[1])
-            error("Batch size of input is unknown")
-        end
-        batch_size = get(shape.dims[1])
+        batch_size = get_shape(first(inputs), 1)
         initial_state = zero_state(cell, batch_size, dtype)
     end
     outputs = Tensor[]

--- a/src/ops/rnn_cell.jl
+++ b/src/ops/rnn_cell.jl
@@ -20,11 +20,6 @@ type BasicRNNCell <: RNNCell
     hidden_size::Int
 end
 
-function check_shape(shape)
-    if shape.rank_unknown || isnull(shape.dims[2])
-        error("Shape must be inferable")
-    end
-end
 
 """
 Form a `RNNCell` with all states initialized to zero.
@@ -37,9 +32,7 @@ output_size(cell::BasicRNNCell) = cell.hidden_size
 state_size(cell::BasicRNNCell) = cell.hidden_size
 
 function (cell::BasicRNNCell)(input, state)
-    shape = get_shape(input)
-    check_shape(shape)
-    N = get(shape.dims[2]) + cell.hidden_size
+    N = get_shape(input, 2) + cell.hidden_size
     T = eltype(state)
     W = get_variable("weights", [N, cell.hidden_size], T)
     B = get_variable("bias", [cell.hidden_size], T)
@@ -91,9 +84,7 @@ function zero_state(cell::LSTMCell, batch_size, T)
 end
 
 function (cell::LSTMCell)(input, state)
-    shape = get_shape(input)
-    check_shape(shape)
-    N = get(shape.dims[2]) + cell.hidden_size
+    N = get_shape(input, 2) + cell.hidden_size
     T = eltype(state)
     X = cat(Tensor, 2, input, state.h)
 
@@ -130,9 +121,7 @@ state_size(cell::GRUCell) = cell.hidden_size
 
 function (cell::GRUCell)(input, state)
     T = eltype(state)
-    shape = get_shape(input)
-    check_shape(shape)
-    N = get(shape.dims[2]) + cell.hidden_size
+    N = get_shape(input, 2) + cell.hidden_size
     X = cat(Tensor, 2, input, state)
     Wz = get_variable("Wz", [N, cell.hidden_size], T)
     Wr = get_variable("Wr", [N, cell.hidden_size], T)

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -168,36 +168,36 @@ end
 Base.cat(::Type{Tensor}, dim, values...) = concat(dim-1, values)
 
 """
-pack(values; axis=0, name="")
+pack(values; axis=1, name="")
 
 Packs a list of rank-R tensors into one rank-(R+1) tensor.
 
 Packs the list of tensors in values into a tensor with rank one higher than each tensor in values, by packing them along the axis dimension. Given a list of length N of tensors of shape (A, B, C);
 
-if axis == 0 then the output tensor will have the shape (N, A, B, C). if axis == 1 then the output tensor will have the shape (A, N, B, C). Etc.
+if axis == 1 then the output tensor will have the shape (N, A, B, C). if axis == 2 then the output tensor will have the shape (A, N, B, C). Etc.
 
 https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#pack
 """
-function pack(nodes; axis=0, name="Pack")
+function pack(nodes; axis=1, name="Pack")
     local desc
     with_op_name(name) do
         desc = NodeDescription("Pack")
         add_input(desc, [Tensor(_) for _ in nodes])
         desc["N"] = length(nodes)
-        desc["axis"] = axis
+        desc["axis"] = axis -1
     end
     Tensor(Operation(desc), 1)
 end
 
-function unpack(value; num=0, axis=0, name="Unpack")
+function unpack(value; num=nothing, axis=1, name="Unpack")
+    num_split = num==nothing ? get_shape(value, axis) : num
     local desc
     with_op_name(name) do
         desc = NodeDescription("Unpack")
         add_input(desc, value)
-        desc["num"] = num
-        desc["axis"] = axis
+        desc["num"] = num_split
+        desc["axis"] = axis - 1
     end
-    num_split = num==0 ? size(value, axis) : num
     op = Operation(desc)
     [Tensor(op, _) for _ in 1:num_split]
 end

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -66,6 +66,16 @@ function get_shape(n::TensorFlow.AbstractTensor)
     _get_shape(n)
 end
 
+function get_shape(n::TensorFlow.AbstractTensor, dim::Integer)
+    shape = get_shape(n)
+    if shape.rank_unknown
+        error("Shape of $(n.op.name) is unknown")
+    end
+    if isnull(shape.dims[dim])
+        error("Shape of $(n.op.name) in dim $(dim) is unknown")
+    end
+    get(shape.dims[dim])
+end
 
 function _get_shape(n::TensorFlow.AbstractTensor)
     t = Tensor(n)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,8 @@
+
+k = placeholder(Float32; shape=[10,20, -1])
+@test get_shape(k,2) == 20
+@test_throws ErrorException get_shape(k, 3)
+@test_throws BoundsError get_shape(k, 4)
+
+@test_throws ErrorException get_shape(placeholder(Float32), 1)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using TensorFlow
 using Base.Test
 
 include("hello.jl")
+include("core.jl")
 include("math.jl")
 include("debug.jl")
 include("comp.jl")

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -14,6 +14,7 @@ one_tens = ones(Tensor, (5,5))
 @test Int32[5,5,1] == run(sess, TensorFlow.shape(pack(split(2, 5, one_tens), axis=1)))
 
 @test ones(Float32, 5,5) == run(sess, pack(unpack(one_tens, num=5)))
+@test ones(Float32, 5,5) == run(sess, pack(unpack(one_tens, axis=1)))
 
 @test ones(5,5,1) == run(sess, expand_dims(one_tens, 2))
 


### PR DESCRIPTION
unpack was broken for three reasons;
1. if `num` was not provided the path to calculate it used `size` rather than `get_shape`
2. `axis` was 0-based not 1 based (this was also wrong in `pack` so that was fixed too)
3. The way defaulting `num`/`axis` works is not part of the tensor flow operation AFAICT, and need to be done by the wrapper.

In solving 1, i defined a `get_shape(x, dim)` that corresponds to `size(x, dim)`.
And throws exceptions if the shape is unknow or the shape for that axis is unknown.
I then went through and replaces the handful of times this pattern was used.
Arguable the new error message is less clear. But also arguably it is more specific.
If you do not like, you could cherry pick just the first commit.


This is a breaking change, because of the `axis` argument becoming 1 based.