### PR TITLE
Give `squeeze` a default dimension, similar to the python API

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -330,12 +330,14 @@ Returns:
 Raises:
   ValueError: When both `squeeze_dims` and `axis` are specified.
 """
-function Base.squeeze(x::AbstractTensor, squeeze_dims; name="squeeze")
+function Base.squeeze(x::AbstractTensor, squeeze_dims=nothing; name="squeeze")
     local desc
     with_op_name(name) do
         desc = NodeDescription("Squeeze")
         add_input(desc, x)
-        set_attr_list(desc, "squeeze_dims", squeeze_dims-1)
+        if !(squeeze_dims === nothing)
+            set_attr_list(desc, "squeeze_dims", squeeze_dims-1)
+        end
     end
     Tensor(Operation(desc), 1)
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -47,3 +47,12 @@ let
     y = constant([1, 2, 3])
     @test run(sess, y[indices]) == run(sess, y[mask]) == [1, 3]
 end
+
+# Test `squeeze()` works when given explicit dimensions, fails on incorrect explicit dimensions,
+# and works when given no explicit dimension
+sq_ones = ones(Tensor, (10, 1, 5, 1))
+@test size(run(sess, squeeze(sq_ones))) == (10,5)
+@test size(run(sess, squeeze(sq_ones,[2,4]))) == (10,5)
+@test size(run(sess, squeeze(sq_ones,[2]))) == (10,5,1)
+@test_throws TensorFlow.TFException run(sess, squeeze(sq_ones,[1]))
+


### PR DESCRIPTION
This allows one to use `squeeze(z)` to automagically get rid of those pesky `1` dimensions.