### PR TITLE
=Add not_implemented for log_poisson_loss

### DIFF
--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -306,6 +306,9 @@ end
 @not_implemented function sampled_softmax_loss()
 end
 
+@not_implemented function log_poisson_loss()
+end
+
 @not_implemented function batch_normalization(x, mean, variance, offset, scale, variable_epsilon; name="")
 
 end


### PR DESCRIPTION
`log_poisson_loss` was exported, but not defined.
This causes weirdities when it comes to using reflection and with some code-completion systems.
I added a `@not_implemented` definition, that someone who actually uses it can replace.

(Coincidentally, https://github.com/tensorflow/tensorflow/issues/4097 is the same issue, but in Python)