### PR TITLE
Improve Shape Inference for things that take lists of Tensors

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -155,20 +155,25 @@ end
 """
 concat(dim, values; name="")
 
+Concatenates the list of tensors `values` along dimension `dim` (1-based).  If
+`values[i].shape = [D1, D2, ... Daxis(i), ...Dn]`, the concatenated
+result has shape `[D1, D2, ... Rdim, ...Dn]`,
+where `Rdim=sum(Daxis(i))`.
+
 https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#concat
 """
 function concat(dim, values; name=nothing)
     local desc
     with_op_name(name, "Concat") do
         desc = NodeDescription("Concat")
-        add_input(desc, Tensor(convert_number(Int32, dim)))
+        add_input(desc, Tensor(convert_number(Int32, dim - 1)))
         add_input(desc, [Tensor(_) for _ in values])
         desc["N"] = length(values)
     end
     Tensor(Operation(desc), 1)
 end
 
-Base.cat(::Type{Tensor}, dim, values...) = concat(dim-1, values)
+Base.cat(::Type{Tensor}, dim, values...) = concat(dim, values)
 
 """
 pack(values; axis=1, name="")

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -174,6 +174,7 @@ function concat(dim, values; name=nothing)
 end
 
 Base.cat(::Type{Tensor}, dim, values...) = concat(dim, values)
+Base.cat(dim, values::AbstractTensor...) = concat(dim, values)
 
 """
 pack(values; axis=1, name="")

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -19,12 +19,29 @@ function TensorShape(dims::Vector{Nullable{Int}})
 end
 
 function TensorShape(dims::Vector)
-    TensorShape([Nullable{Int64}(_) for _ in dims])
+    TensorShape([_<0 ? Nullable{Int64}() : Nullable{Int64}(_) for _ in dims])
 end
 
 function TensorShape(dim::Void)
     TensorShape(Nullable{Int}[], true)
 end
+
+
+function Base.isequal(ts1::TensorShape, ts2::TensorShape)
+    ts1.rank_unknown && ts2.rank_unknown ||
+    !ts1.rank_unknown && !ts2.rank_unknown && isequal(ts1.dims, ts2.dims)
+end
+
+Base.:(==)(ts1::TensorShape, ts2::TensorShape) = isequal(ts1, ts2)
+
+function Base.hash(ts::TensorShape, h::UInt64)
+    if ts.rank_unknown
+        h #All tensors with unknown rank hash the same, as they are equal
+    else
+        hash(ts.dims, h)
+    end
+end
+
 
 function Base.show(io::IO, shape::TensorShape)
     get_dim_name = x->begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,11 +1,5 @@
 using Base.Test
-
-k = placeholder(Float32; shape=[10,20, -1])
-@test get_shape(k,2) == 20
-@test_throws ErrorException get_shape(k, 3)
-@test_throws BoundsError get_shape(k, 4)
-
-@test_throws ErrorException get_shape(placeholder(Float32), 1)
+using TensorFlow
 
 #################
 # Graph importing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ y, s1 = cell(x, s0)
 tests = [
     "hello.jl",
     "core.jl",
+    "shape_inference.jl",
     "math.jl",
     "debug.jl",
     "comp.jl",

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -26,8 +26,8 @@ n = placeholder(Float32)
 @test get_shape(m+k) == TensorShape([10, 20, -1])
 
 ## Concat
-@test get_shape(concat(2,[m,m])) == TensorShape([10, 40, 30])
-@test get_shape(concat(2, [m,k]))  == TensorShape([10, 40, 30])
-@test get_shape(concat(2, [k,m]))  == TensorShape([10, 40, 30])
-@test get_shape(concat(3, [m,k]))  == TensorShape([10,20, -1])
+@test get_shape(cat(2, m,m)) == TensorShape([10, 40, 30])
+@test get_shape(cat(2, m,k))  == TensorShape([10, 40, 30])
+@test get_shape(cat(2, k,m))  == TensorShape([10, 40, 30])
+@test get_shape(cat(3, m,k))  == TensorShape([10,20, -1])
 

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -1,0 +1,27 @@
+using TensorFlow
+using Base.Test
+
+k = placeholder(Float32; shape=[10, 20, -1])
+m = placeholder(Float32; shape=[10, 20, 30])
+n = placeholder(Float32)
+
+@test get_shape(k,2) == 20
+@test_throws ErrorException get_shape(k, 3)
+@test_throws BoundsError get_shape(k, 4)
+@test_throws ErrorException get_shape(n, 1)
+
+
+@test get.(get_shape(pack([m,m,m])).dims) == [3, 10, 20, 30]
+@test get.(get_shape(pack([m,m,m],axis=2)).dims) == [10, 3, 20, 30]
+@test get.(get_shape(pack([m,k])).dims) == [2, 10, 20, 30]
+@test get.(get_shape(pack([k,m])).dims) == [2, 10, 20, 30]
+@test get.(get_shape(pack([m,n])).dims) == [2, 10, 20, 30]
+@test get_shape(pack([n,n])).rank_unknown
+@test get.(get_shape(pack([k,k])).dims[1:3]) == [2, 10, 20]
+@test isnull(get_shape(pack([k,k])).dims[4])
+
+@test get.(get_shape(m+m).dims) == [10, 20, 30]
+@test get_shape(m+n).rank_unknown
+@test get_shape(m+k, 1) == 10
+@test get_shape(m+k, 2) == 20
+@test isnull(get_shape(m+k).dims[3])


### PR DESCRIPTION
This PR fixes shape inference for `concat` and `pack`

 - `concat` would fail at inference if a vector with some dimensions unknown was first
 - `pack` wouldn't do type inference at all

It also leaves  shape inference for `add_n` wrong, but in a different way.
It is still not broadcasting, but now it gives errors instead of being wrong in broadcast scenarios.
It really wouldn't be too hard to make it correct.
It is just the same generalisation for unification to make a multiargument broadcast.
Which I could do in this PR, or I could do it later seperately.

Also it makes Concat 1 based. Because that was killing me every time I used it.
I guess a deprecation strategy could be employed for that.
Like deprecating concat infavor of cat (which was alway correct).
I put that in it's own commit so it could be cherry picked out. (so long as the testing cat commit is kept)
But I am not sure having it around at all is a good idea -- it just allows for confusing code.