### PR TITLE
=Shape inference and 1-based indexing for ExpandDims

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -254,24 +254,26 @@ expand_dims(input, dim; name="")
 
 Inserts a dimension of 1 into a tensor's shape.
 
-Given a tensor input, this operation inserts a dimension of 1 at the dimension index dim of input's shape. The dimension index dim starts at zero; if you specify a negative number for dim it is counted backward from the end.
+Given a tensor input, this operation inserts a dimension of 1 at the dimension index dim of input's shape. The dimension index dim starts at one; if you specify a non-positive number for dim it is counted backward from the end. With `0` being the last dimension (`end-0`), `-1` being the second last (`end-1`) and so forth
 
-This operation is useful if you want to add a batch dimension to a single element. For example, if you have a single image of shape [height, width, channels], you can make it a batch of 1 image with expand_dims(image, 0), which will make the shape [1, height, width, channels].
+This operation is useful if you want to add a batch dimension to a single element. For example, if you have a single image of shape `[height, width, channels]`, you can make it a batch of 1 image with `expand_dims(image, 1)`, which will make the shape `[1, height, width, channels]`.
 
 Other examples:
 
+```julia
 # 't' is a tensor of shape [2]
-shape(expand_dims(t, 0)) ==> [1, 2]
-shape(expand_dims(t, 1)) ==> [2, 1]
-shape(expand_dims(t, -1)) ==> [2, 1]
+shape(expand_dims(t, 1)) ==> [1, 2]
+shape(expand_dims(t, 2)) ==> [2, 1]
+shape(expand_dims(t, 0)) ==> [2, 1]
 
 # 't2' is a tensor of shape [2, 3, 5]
-shape(expand_dims(t2, 0)) ==> [1, 2, 3, 5]
-shape(expand_dims(t2, 2)) ==> [2, 3, 1, 5]
-shape(expand_dims(t2, 3)) ==> [2, 3, 5, 1]
-This operation requires that:
+shape(expand_dims(t2, 1)) ==> [1, 2, 3, 5]
+shape(expand_dims(t2, 3)) ==> [2, 3, 1, 5]
+shape(expand_dims(t2, 4)) ==> [2, 3, 5, 1]
+```
 
--1-input.dims() <= dim <= input.dims()
+This operation requires that:
+-input.dims() <= dim <= input.dims()+1
 
 This operation is related to squeeze(), which removes dimensions of size 1.
 
@@ -291,7 +293,7 @@ function expand_dims(input, dim; name=nothing)
     with_op_name(name, "ExpandDims") do
         desc = NodeDescription("ExpandDims")
         add_input(desc, Tensor(input))
-        add_input(desc, Tensor(convert_number(Int32,dim)))
+        add_input(desc, Tensor(convert_number(Int32,dim-1)))
     end
     Tensor(Operation(desc), 1)
 end

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -270,6 +270,9 @@ shape(expand_dims(t, 0)) ==> [2, 1]
 shape(expand_dims(t2, 1)) ==> [1, 2, 3, 5]
 shape(expand_dims(t2, 3)) ==> [2, 3, 1, 5]
 shape(expand_dims(t2, 4)) ==> [2, 3, 5, 1]
+shape(expand_dims(t2, 0)) ==> [2, 3, 5, 1]
+shape(expand_dims(t2, -1)) ==> [2, 3, 1, 5]
+
 ```
 
 This operation requires that:

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -5,6 +5,7 @@ import TensorFlow.ShapeInference: TensorShape
 k = placeholder(Float32; shape=[10, 20, -1])
 m = placeholder(Float32; shape=[10, 20, 30])
 n = placeholder(Float32)
+i = placeholder(Int32; shape=[])
 
 @test get_shape(k,2) == 20
 @test_throws ErrorException get_shape(k, 3)
@@ -68,3 +69,12 @@ end
 @test get_shape(gather_nd(m, reshape([3], (1,1,1)))) == TensorShape([1, 1, 20, 30]) #1x1x1
 
 
+## ExpandDims
+@test get_shape(expand_dims(m, 1)) == TensorShape([1, 10, 20, 30])
+@test get_shape(expand_dims(m, 2)) == TensorShape([10, 1, 20, 30])
+@test get_shape(expand_dims(m, 3)) == TensorShape([10, 20, 1, 30])
+@test get_shape(expand_dims(m, 4)) == TensorShape([10, 20, 30, 1])
+@test get_shape(expand_dims(m, 0)) == TensorShape([10, 20, 30, 1])
+@test get_shape(expand_dims(m, -1)) == TensorShape([10, 20, 1, 30])
+@test get_shape(expand_dims(m, i)) == TensorShape([-1, -1, -1, -1])
+@test get_shape(expand_dims(n, 2)) == TensorShape(nothing)

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -15,7 +15,10 @@ one_tens = ones(Tensor, (5,5))
 @test ones(Float32, 5,5) == run(sess, pack(unpack(one_tens, num=5)))
 # @test ones(Float32, 5,5) == run(sess, pack(unpack(one_tens, axis=1)))
 
-@test ones(5,5,1) == run(sess, expand_dims(one_tens, 2))
+@test ones(1,5,5) == run(sess, expand_dims(one_tens, 1))
+@test ones(5,1,5) == run(sess, expand_dims(one_tens, 2))
+@test ones(5,1,5) == run(sess, expand_dims(one_tens, -1))
+@test ones(5,5,1) == run(sess, expand_dims(one_tens, 0))
 
 @test 2 == run(sess, rank(one_tens))
 


### PR DESCRIPTION
ExpandDims now has `get_shape` working.
(Before it just always returned `[Tensor(nothing)]`)

And it has now has 1 based indexing.