### PR TITLE
Make shape inference work for Unpack

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -209,11 +209,11 @@ If `value.shape[axis]` is not known, `ValueError` is raised.
 
 For example, given a tensor of shape `(A, B, C, D)`;
 
-If `axis == 0` then the i'th tensor in `output` is the slice
+If `axis == 1` then the i'th tensor in `output` is the slice
   `value[i, :, :, :]` and each tensor in `output` will have shape `(B, C, D)`.
   (Note that the dimension unpacked along is gone, unlike `split`).
 
-If `axis == 1` then the i'th tensor in `output` is the slice
+If `axis == 2` then the i'th tensor in `output` is the slice
   `value[:, i, :, :]` and each tensor in `output` will have shape `(A, C, D)`.
 Etc.
 

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -616,6 +616,23 @@ register_shape("Pack") do op
     [union_dims]
 end
 
+register_shape("Unpack") do op
+    whole_value = get_input(op, 1)
+    whole_shape = _get_shape(whole_value)
+    num_split = get_attr(op,"num", Int)
+
+    if whole_shape.rank_unknown
+        # We don't know the size of the input,
+        # so we don't know the size of the output
+        # we do know how many their will be.
+        fill(TensorShape(nothing), num_split)
+    else
+        axis = get_attr(op, "axis", Int) + 1
+        slice_shape = copy(whole_shape)
+        deleteat!(slice_shape.dims, axis)
+        fill(slice_shape, num_split)
+    end
+end
 
 register_shape("AddN") do op
     inputs = [get_input(op, i) for i in 1:tf.get_input_list_length(op, "inputs")]

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -20,6 +20,26 @@ n = placeholder(Float32)
 @test get_shape(pack([n,n])).rank_unknown
 @test get_shape(pack([k,k])) == TensorShape([2, 10, 20, -1])
 
+## Unpack
+for ii in 1:10
+    @test get_shape(unpack(m)[ii]) == TensorShape([20, 30])
+end
+
+for ii in 1:20
+    @test get_shape(unpack(k, axis=2)[ii]) == TensorShape([10, -1])
+end
+
+for ii in 1:3
+    @test get_shape(unpack(n, num=3)[ii]) == TensorShape(nothing)
+end
+
+
+
+### Pack/UnPack
+@test get_shape(pack(unpack(m))) == get_shape(m)
+@test get_shape(pack(unpack(k))) == get_shape(k)
+
+
 ## Add
 @test get_shape(m+m) == TensorShape([10, 20, 30])
 @test get_shape(m+n).rank_unknown


### PR DESCRIPTION
Now Unpack too can have shape inference.

I am becoming less sure on why one would ever practically use the `num` argument.
Since it means that at this point in the code you know the size of in a particular dimenesion as a julia Int,
but for some reason that value is `unknown` in the TensorShape of your input.
Seems like either the shape inference prior has failed for some reason (and so you would use `reshape` as a ShapeAssert), or you chose not to enter a known shape.

Anyway, it works too.