### PR TITLE
gather_nd

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -476,7 +476,7 @@ end
 
 #For x[1,2,3] etc
 function Base.getindex(params::AbstractTensor, indices...)
-    inds::Vector = collect(indices) # Want Vector, not tuple
+    inds::Vector = collect(indices) # Want Vector, not tuple. Could be a vector of Tensors though
     if eltype.(inds) ⊆ (Int32, Int64)
         gather_nd(params, inds)
     else

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -526,7 +526,6 @@ function gather(params, indices; validate_indices=true, name=nothing)
     Tensor(Operation(desc), 1)
 end
 
-#TODO update the way matrixes are written in these docs -- so not wrriten asvectors of vectors
 """
 ### `gather_nd(params, indices, name="")` {#gather_nd}
 

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -528,7 +528,7 @@ end
 
 #TODO update the way matrixes are written in these docs -- so not wrriten asvectors of vectors
 """
-### `tf.gather_nd(params, indices, name=None)` {#gather_nd}
+### `gather_nd(params, indices, name="")` {#gather_nd}
 
 Gather values or slices from `params` according to `indices`.
 
@@ -551,95 +551,29 @@ Produces an output tensor with shape
 Some examples below.
 
 Simple indexing into a matrix:
-
 ```julia
-    indices = [1, 1], [2, 2]]
-    params = [['a', 'b'], ['c', 'd']]
+    indices = [1 1; 2 2]""
+    params = ['a' 'b';  'c' 'd']
     output = ['a', 'd']
 ```
 
 Slice indexing into a matrix:
-
 ```julia
-    indices = [[2], [1]]
-    params = [['a', 'b'], ['c', 'd']]
-    output = [['c', 'd'], ['a', 'b']]
-```
-
-Indexing into a 3-tensor:
-
-```julia
-    indices = [[2]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = [[['a1', 'b1'], ['c1', 'd1']]]
-
-
-    indices = [[1, 2], [2, 1]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = [['c0', 'd0'], ['a1', 'b1']]
-
-
-    indices = [[1, 1, 2], [2, 1, 2]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = ['b0', 'b1']
-```
-
-Batched indexing into a matrix:
-
-```julia
-    indices = [[[1, 1]], [[1, 2]]]
-    params = [['a', 'b'], ['c', 'd']]
-    output = [['a'], ['b']]
-```
-
-Batched slice indexing into a matrix:
-
-```julia
-    indices = [[[2]], [[1]]]
-    params = [['a', 'b'], ['c', 'd']]
-    output = [[['c', 'd']], [['a', 'b']]]
-```
-
-Batched indexing into a 3-tensor:
-
-```julia
-    indices = [[[2]], [[1]]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = [[[['a1', 'b1'], ['c1', 'd1']]],
-              [[['a0', 'b0'], ['c0', 'd0']]]]
-
-    indices = [[[1, 2], [2, 1]], [[1, 1], [2, 2]]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = [[['c0', 'd0'], ['a1', 'b1']],
-              [['a0', 'b0'], ['c1', 'd1']]]
-
-
-    indices = [[[1, 1, 2], [2, 1, 2]], [[1, 2, 2], [2, 2, 1]]]
-    params = [[['a0', 'b0'], ['c0', 'd0']],
-              [['a1', 'b1'], ['c1', 'd1']]]
-    output = [['b0', 'b1'], ['d0', 'c1']]
+    indices = [2  1]'
+    params = ['a' 'b'; 'c' 'd']
+    output = ['c' 'd'; 'a' 'b']
 ```
 
 ##### Args:
-
-
 *  <b>`params`</b>: A `Tensor`. `P-D`.  The tensor from which to gather values.
 *  <b>`indices`</b>: A `Tensor`. Must be one of the following types: `int32`, `int64`.
     `Q-D`.  Index tensor having shape `[d_1, ..., d_{Q-1}, K]`. 1 based
 *  <b>`name`</b>: A name for the operation (optional).
 
 ##### Returns:
-
   A `Tensor`. Has the same type as `params`.
   `(P+Q-K-1)-D`.  Values from `params` gathered from indices given by
   `indices`.
-
-
 """
 function gather_nd(params, indicies; name=nothing)
     local desc

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -599,6 +599,18 @@ register_shape("Gather") do op
     [TensorShape(vcat(index_dims.dims, value_dims.dims[2:end]))]
 end
 
+register_shape("GatherNd") do op
+    value_dims = _get_shape(get_input(op, 1))
+    index_dims = _get_shape(get_input(op, 2))
+    if index_dims.rank_unknown || value_dims.rank_unknown || isnull(index_dims.dims[end])
+        return [TensorShape(nothing)]
+    end
+    rr=get(index_dims.dims[end])
+
+    [TensorShape(vcat(index_dims.dims[1:end-1], value_dims.dims[rr+1:end]))]
+end
+
+
 function todo_register_shape(name)
 end
 

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -107,12 +107,12 @@ Runs shape inference to return the shape of the tensor produced by the given ope
 
 Note this runs *statically*. Use the `shape` operation to dynamically get the shape of an operation.
 """
-function get_shape(n::TensorFlow.AbstractTensor)
+function get_shape(n::tf.AbstractTensor)
     empty!(shape_cache)
     _get_shape(n)
 end
 
-function get_shape(n::TensorFlow.AbstractTensor, dim::Integer)
+function get_shape(n::tf.AbstractTensor, dim::Integer)
     shape = get_shape(n)
     if shape.rank_unknown
         error("Shape of $(n.op.name) is unknown")
@@ -123,7 +123,11 @@ function get_shape(n::TensorFlow.AbstractTensor, dim::Integer)
     get(shape.dims[dim])
 end
 
-function _get_shape(n::TensorFlow.AbstractTensor)
+# Overload `Base.size` so that [3:4, 1:end] etc works
+Base.size(n::tf.AbstractTensor, dim::Integer) = get_shape(n, dim)
+
+
+function _get_shape(n::tf.AbstractTensor)
     t = Tensor(n)
     cache_key = (t.op.name, t.value_index)
     if haskey(shape_cache, cache_key)

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -31,3 +31,20 @@ n = placeholder(Float32)
 @test get_shape(cat(2, k,m))  == TensorShape([10, 40, 30])
 @test get_shape(cat(3, m,k))  == TensorShape([10,20, -1])
 
+## GatherNd
+@test get_shape(gather_nd(m, [3])) == TensorShape([20, 30]) #1
+
+@test get_shape(gather_nd(m, [5,6,6])) == TensorShape([]) #3
+@test get_shape(gather_nd(m, [5 6 6])) == TensorShape([1])#1x3
+@test get_shape(gather_nd(m, [5 6 6]')) == TensorShape([3, 20, 30])#3x1
+
+@test get_shape(gather_nd(m, [2 5; 2 6; 2 7])) == TensorShape([3, 30]) #2x3
+@test get_shape(gather_nd(m, [2 2 2; 5 6 7])) == TensorShape([2]) #3x2
+
+@test get_shape(gather_nd(m, [5,6])) == TensorShape([30]) #2
+@test get_shape(gather_nd(m, [5 6]')) == TensorShape([2, 20, 30]) #2x1
+
+@test get_shape(gather_nd(m, reshape([3], (1,1)))) == TensorShape([1, 20, 30]) #1x1
+@test get_shape(gather_nd(m, reshape([3], (1,1,1)))) == TensorShape([1, 1, 20, 30]) #1x1x1
+
+

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -47,10 +47,10 @@ sq_ones = ones(Tensor, (10, 1, 5, 1))
 # getindex related methods (getindex overload and the methods behind it)
 
 # Test values
-srand(1) #constant seed for consistant test
-x_jl = rand(5,3)
+x_jl = [10x+y for x in 1:5, y in 1:7]
 x = constant(x_jl)
-
+w_jl = [100x+10y+z for x in 1:5, y in 1:7, z in 1:3]
+w = constant(w_jl)
 y = constant([1, 2, 3])
 
 ### Mask (bool array)
@@ -58,19 +58,22 @@ y = constant([1, 2, 3])
 mask = constant([true, false, true])
 @test run(sess, boolean_mask(y,mask))  == run(sess, y[mask]) == [1, 3]
 
-### Index/Gather (int/ int array)
+### Gather (int/ int array) / Index
 
 @test ones(Float32, 2, 5) == run(sess, gather(one_tens, [1, 2]))
 @test run(sess, y[[1, 3]]) == [1, 3]
 @test run(sess, y[2]) == 2
 
-### Cartean Index/Gather-nd
-@test run(sess, gather_nd(x,[2, 3])) == x_jl[2,3]
+### Gather-nd / Cartean Index/Slice
+@test run(sess, gather_nd(x, [2, 3])) == x_jl[2,3]
 @test run(sess, x[2,3]) == x_jl[2,3]
 
+@test run(sess, gather_nd(x, [3])) == x_jl[3,:]
+
+@test run(sess, gather_nd(x, [1 1; 2 3])) == [x_jl[1,1], x_jl[2,3]]
+@test run(sess, gather_nd(x, [1 2]')) == [x_jl[1,:]'; x_jl[2,:]']
 
 ### Slice
-
 # to do make sure we slice the right indices
 @test ones(Float32, 5).' == run(sess, slice(one_tens, [0, 0], [1, -1]))
 


### PR DESCRIPTION
This PR adds support of [GatherNd](https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops/slicing_and_joining#gather_nd)

Using it for slicing is a really weird to me most of the time. (though I think I have a really handy use for it for what I am actually doing right now).
Slice is more sane to me a lot of the time.

But what this does give us is indexing.
So now `X[2,3]` will work. (Cool but maybe not super useful)
No slicing in `get_index` yet; I have some thoughts toward it.

