### PR TITLE
Be smarter about collections

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -109,6 +109,9 @@ macro with_def_graph(ex)
 end
 
 @with_def_graph function add_to_collection(g::Graph, name, node)
+    if !haskey(g.collections, name)
+        g.collections[name] = []
+    end
     push!(g.collections[name], node)
 end
 
@@ -118,7 +121,10 @@ Returns a collection attached to the graph `g` named `name`
 function get_collection end
 
 @with_def_graph function get_collection(g::Graph, name)
-    g.collections[name]
+    if !haskey(g.collections, name)
+        return []
+    end
+    return g.collections[name]
 end
 
 

--- a/src/ops/summaries.jl
+++ b/src/ops/summaries.jl
@@ -132,7 +132,7 @@ Returns:
   buffer resulting from the merging.
 """
 function merge_all_summaries(key=:Summaries)
-    merge_summary(get_collection(:Summaries), collections=[])
+    merge_summary(get_collection(key), collections=[])
 end
 
 """


### PR DESCRIPTION
This allows you to pass in new collection names into things like summaries, then get them back out with `merge_all_summaries()`.