### PR TITLE
Fix Gather so its grad can be calculated

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -579,7 +579,7 @@ Slice indexing into a matrix:
     with_op_name(name, "GatherNd") do
         desc = NodeDescription("GatherNd")
         add_input(desc, Tensor(params))
-        add_input(desc, Tensor(indicies)-1)
+        add_input(desc, cast(Tensor(indicies)-1, Int32))
     end
     Tensor(Operation(desc), 1)
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -73,7 +73,17 @@ mask = constant([true, false, true])
 @test run(sess, gather_nd(x, [1 1; 2 3])) == [x_jl[1,1], x_jl[2,3]]
 @test run(sess, gather_nd(x, [1 2]')) == [x_jl[1,:]'; x_jl[2,:]']
 
+
 ### Slice
 # to do make sure we slice the right indices
 @test ones(Float32, 5).' == run(sess, slice(one_tens, [0, 0], [1, -1]))
 
+############
+# Check it gather_nd can make a network
+sess2 = Session(Graph())
+embs = get_variable("tt2", (10,10), Float64)
+vals = gather_nd(embs,[2])
+cost = reduce_sum(vals)
+optimizer = train.minimize(train.AdamOptimizer(0.1), cost)
+run(sess2, initialize_all_variables())
+@test length(run(sess2, vals)) == 10


### PR DESCRIPTION
I am not 100% sure why, but it seems that when GatherNd is differencated to ScatterNd, the shape comes back as Int32, and the indicies as the type they were on GatherNd.

[ScatterNd](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/scatter-nd) requires that it's shape input and it's gather input have same type.

This fixes that