### PR TITLE
Mention building from source to get around CUDA version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Pkg.build("TensorFlow")
 ```
 
 CUDA 8.0 and cudnn are required for GPU usage.
+If you need to use a different version of CUDA you can [compile libtensorflow from source](#optional-building-the-tensorflow-library)
 
 ## Logistic regression example
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ ENV["TF_USE_GPU"] = "1"
 Pkg.build("TensorFlow")
 ```
 
-CUDA 7.5 and cudnn are required for GPU usage.
+CUDA 8.0 and cudnn are required for GPU usage.
 
 ## Comparison to Python API
 


### PR DESCRIPTION
I now have TensorFlow.jl working with CUDA 7.5.
Yay