### PR TITLE
Use libtensorflow.so instead of libtensorflow_c.so.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ sudo pip3 install --upgrade $TF_BINARY_URL
 If you want to build your own version of the TensorFlow binary library instead of relying on the one that is installed with
 `Pkg.build("TensorFlow")`, follow the instructions from https://www.tensorflow.org/install/install_sources, except:
 
-* In the section "Build the pip package", instead run `bazel build --config=opt //tensorflow:libtensorflow_c.so`.
-* Then copy the file "bazel-bin/tensorflow/libtensorflow_c.so" to the "deps/usr/bin" directory in the TensorFlow.jl package.
-* On OS X, rename the file to `libtensorflow_c.dylib`.
+* In the section "Build the pip package", instead run `bazel build --config=opt //tensorflow:libtensorflow.so`.
+* Then copy the file "bazel-bin/tensorflow/libtensorflow.so" to the "deps/usr/bin" directory in the TensorFlow.jl package.
+* On OS X, rename the file to `libtensorflow.dylib`.
 
 A convenience script is included to use Docker to easily build the library. Just install docker and run `julia build_libtensorflow.so` from the "deps" directory of the TensorFlow.jl package.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -72,6 +72,8 @@ function try_unzip()
     end
 end
 
+const cur_version = "1.0.0-rc1"
+
 @static if is_apple()
     r = Requests.get("https://storage.googleapis.com/malmaud-stuff/tensorflow_mac_$cur_version.zip")
     open(joinpath(base, "downloads/tensorflow.zip"), "w") do file

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,7 +16,7 @@ function try_unzip()
     try
         run(`unzip -o $base/downloads/tensorflow.zip`)
     catch err
-        if !isfile(joinpath(base, "libtensorflow_c.so"))
+        if !isfile(joinpath(base, "libtensorflow.so"))
             throw(err)
         else
             warn("Problem unzipping: $err")
@@ -32,7 +32,7 @@ const cur_version = "1.0.0-rc1"
         write(file, r.data)
     end
     try_unzip()
-    mv("libtensorflow_c.so", "usr/bin/libtensorflow_c.dylib", remove_destination=true)
+    mv("libtensorflow.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
 end
 
 @static if is_linux()
@@ -48,5 +48,5 @@ end
         write(file, r.data)
     end
     try_unzip()
-    mv("libtensorflow_c.so", "usr/bin/libtensorflow_c.so", remove_destination=true)
+    mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,6 +12,10 @@ if !isdir(bin_dir)
     run(`mkdir -p $bin_dir`)
 end
 
+# When TensorFlow 1.1 is released, use the official release binaries
+# of the TensorFlow C library. Do this by setting cur_version to 1.1.0
+# and then replacing the blocks below with:
+#=
 function try_unzip()
     try
         run(`tar -xvzf $base/downloads/tensorflow.tar.gz --strip-components=2 ./lib/libtensorflow.so`)
@@ -23,8 +27,6 @@ function try_unzip()
         end
     end
 end
-
-const cur_version = "1.0.0"
 
 @static if is_apple()
     if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
@@ -55,4 +57,42 @@ end
     end
     try_unzip()
     mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
+end
+=#
+
+function try_unzip()
+    try
+        run(`unzip -o $base/downloads/tensorflow.zip`)
+    catch err
+        if !isfile(joinpath(base, "libtensorflow_c.so"))
+            throw(err)
+        else
+            warn("Problem unzipping: $err")
+        end
+    end
+end
+
+@static if is_apple()
+    r = Requests.get("https://storage.googleapis.com/malmaud-stuff/tensorflow_mac_$cur_version.zip")
+    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
+        write(file, r.data)
+    end
+    try_unzip()
+    mv("libtensorflow_c.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
+end
+
+@static if is_linux()
+    if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
+        info("Building TensorFlow.jl for use on the GPU")
+        url = "https://storage.googleapis.com/malmaud-stuff/tensorflow_linux_$cur_version.zip"
+    else
+        info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
+        url = "https://storage.googleapis.com/malmaud-stuff/tensorflow_linux_cpu_$cur_version.zip"
+    end
+    r = Requests.get(url)
+    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
+        write(file, r.data)
+    end
+    try_unzip()
+    mv("libtensorflow_c.so", "usr/bin/libtensorflow.so", remove_destination=true)
 end

--- a/deps/build_libtensorflow.jl
+++ b/deps/build_libtensorflow.jl
@@ -1,5 +1,5 @@
 #=
-Script for building the Linux version of libtensorflow_c.so.
+Script for building the Linux version of libtensorflow.so.
 
 Requires Docker.
 =#
@@ -7,16 +7,16 @@ Requires Docker.
 if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
     docker_image = "tensorflow/tensorflow:1.0.0-devel-gpu"
     opts = "-c opt --config=cuda"
-    info("Building libtensorflow_c.so for use on the GPU.")
+    info("Building libtensorflow.so for use on the GPU.")
 else
     docker_image = "tensorflow/tensorflow:1.0.0-devel"
     opts = "-c opt"
-    info("Building libtensorflow_c.so for use on the CPU. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rerun this script.")
+    info("Building libtensorflow.so for use on the CPU. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rerun this script.")
 end
 
 build_script = """
 cd /tensorflow;
-bazel build $opts //tensorflow:libtensorflow_c.so
+bazel build $opts //tensorflow:libtensorflow.so
 """
 
 run(`docker pull $docker_image`)
@@ -40,4 +40,4 @@ end
 
 run(`docker run --name=$container_name $docker_image /bin/bash -c $build_script`)
 
-run(`docker cp $(container_name[2:end]):/tensorflow/bazel-bin/tensorflow/libtensorflow_c.so usr/bin`)
+run(`docker cp $(container_name[2:end]):/tensorflow/bazel-bin/tensorflow/libtensorflow.so usr/bin`)

--- a/src/core.jl
+++ b/src/core.jl
@@ -5,7 +5,7 @@ using Compat
 import Base: setindex!, getindex, run, ==
 
 const LIB_BASE = joinpath(dirname(@__FILE__), "..", "deps")
-const LIBTF = joinpath(LIB_BASE, "usr", "bin", "libtensorflow_c")
+const LIBTF = joinpath(LIB_BASE, "usr", "bin", "libtensorflow")
 
 include("py.jl")
 


### PR DESCRIPTION
The two are identical but the former is recommended by the
TensorFlow maintainers and is created in binary releases of
the TensorFlow C library.


The existence of both targets is an unfortunate outcome of tensorflow/tensorflow@783c52e and tensorflow/tensorflow#3830 happening within days of each other.

Note that the TensorFlow C library is now included in binary releases of TensorFlow. The releases are available in URLs of the form:   `https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-TYPE-OS-ARCH-VERSION.tar.gz`. For example:

- CPU-only, Linux, x86_64, 1.0.0: https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.0.0.tar.gz
- GPU-enabled, Linux, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.0.0.tar.gz
- CPU-only, OS X, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.0.0.tar.gz
- GPU-enabled, OS X, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-darwin-x86_64-1.0.0.tar.gz

Perhaps you want to consider using these to speed up getting started with TensorFlow.jl where possible.