### PR TITLE
Fix shape inference for Where/Find 

### DIFF
--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -657,7 +657,8 @@ register_shape("Where") do op
     if shape.rank_unknown
         [TensorShape(nothing)]
     else
-        [TensorShape([Nullable{Int}() for _ in 1:length(shape.dims)])]
+        @show shape.dims
+        [TensorShape([Nullable{Int64}(), Nullable(length(shape.dims))])]
     end
 end
 

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -657,7 +657,6 @@ register_shape("Where") do op
     if shape.rank_unknown
         [TensorShape(nothing)]
     else
-        @show shape.dims
         [TensorShape([Nullable{Int64}(), Nullable(length(shape.dims))])]
     end
 end

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -18,3 +18,7 @@ cond = [true; false; true; true; false]
 cond_tf = TensorFlow.constant(cond)
 result = run(sess, TensorFlow.select(cond_tf, a, b))
 @test [1; 7; 3; 4; 10] == result
+
+
+@test run(sess, find(constant([true,true, false,true]))) == [1 2 4]'
+@test run(sess, find(constant([true true  false true; false true false true]))) == [1 1; 1 2; 1 4; 2 2; 2 4]

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -7,10 +7,22 @@ m = placeholder(Float32; shape=[10, 20, 30])
 n = placeholder(Float32)
 i = placeholder(Int32; shape=[])
 
+
+
+@test get_shape(k) == TensorShape([10, 20, -1])
+@test get_shape(m) == TensorShape([10, 20, 30])
+@test get_shape(n) == TensorShape(nothing)
+@test get_shape(i) == TensorShape([])
+
 @test get_shape(k,2) == 20
 @test_throws ErrorException get_shape(k, 3)
 @test_throws BoundsError get_shape(k, 4)
 @test_throws ErrorException get_shape(n, 1)
+
+## Find (i.e Where)
+@test get_shape(find(placeholder(Bool; shape=[10, 20, 30]))) == TensorShape([-1,3])
+@test get_shape(find(placeholder(Bool; shape=[10, 20, -1]))) == TensorShape([-1,3])
+@test get_shape(find(placeholder(Bool))) == TensorShape(nothing)
 
 ## Pack
 @test get_shape(pack([m,m,m])) == TensorShape([3, 10, 20, 30])


### PR DESCRIPTION
Where/Find can alway infer the second dimenstions shape at compile time.
But never the first.
So this makes that happen.


Very concerningly when I run `julia test/shape_inference.jl`
all tests pass.
Where as if I run `julia test/runtests.jl`
I get:
```
shape_inference: Test Failed
  Expression: get_shape(find(placeholder(Bool; shape=[10,20,30]))) == TensorShape([-1,3])
   Evaluated: TensorShape[?, 10] == TensorShape[?, 3]
 in record(::Base.Test.DefaultTestSet, ::Base.Test.Fail) at ./test.jl:428
```

