### PR TITLE
Make TensorShape allowed to be Immuable

### DIFF
--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -335,7 +335,7 @@ for func in ["Sum", "Prod", "Min", "Max", "All", "Any", "Mean"]
                 for dim in dims
                     to_keep[dim] = false
                 end
-                value_shape.dims = value_shape.dims[to_keep]
+                return [TensorShape(value_shape.dims[to_keep])]
             end
             return [value_shape]
         end

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -131,17 +131,6 @@ function _get_shape(v::Variable)
     return _get_shape(get_input(v.assign_node, 2))
 end
 
-function to_shape(x::AbstractArray)
-    TensorShape(map(to_shape, x))
-end
-
-function to_shape(x)
-    if x==-1
-        return Nullable{Int}()
-    else
-        return Nullable(x)
-    end
-end
 
 const shape_inferer = Dict{String, Function}()
 

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -84,7 +84,6 @@ end
 @test get_shape(-k) == get_shape(k)
 @test get_shape(k+1) == get_shape(k)
 @test get_shape(k-1) == get_shape(k)
-@test get_shape(k*2) == get_shape(k)
 
 @test get_shape(1+k) == get_shape(k)
 @test get_shape(1-k) == get_shape(k)

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -78,3 +78,14 @@ end
 @test get_shape(expand_dims(m, -1)) == TensorShape([10, 20, 1, 30])
 @test get_shape(expand_dims(m, i)) == TensorShape([-1, -1, -1, -1])
 @test get_shape(expand_dims(n, 2)) == TensorShape(nothing)
+
+
+## Basic Operations
+@test get_shape(-k) == get_shape(k)
+@test get_shape(k+1) == get_shape(k)
+@test get_shape(k-1) == get_shape(k)
+@test get_shape(k*2) == get_shape(k)
+
+@test get_shape(1+k) == get_shape(k)
+@test get_shape(1-k) == get_shape(k)
+@test get_shape(2*k) == get_shape(k)


### PR DESCRIPTION
This unbreaks `get_shape` for `["Sum", "Prod", "Min", "Max", "All", "Any", "Mean"]`

Which was broken by https://github.com/malmaud/TensorFlow.jl/commit/ec0170e5144cce3d83770f86f4f9ee8b643a09ea#diff-ac236c9f23e3c15683602f303d89d8cdR140

And adds some test cases around that.
and a little refactoring while I had it open