### PR TITLE
.!= was broken on julia 0.5. 

### DIFF
--- a/src/ops/comparison.jl
+++ b/src/ops/comparison.jl
@@ -37,6 +37,7 @@ if VERSION < v"0.6-"
         push!(func_list, (func_name, Symbol(string(".", sym))))
     end
     push!(func_list, (:equal, :(.==)))
+    push!(func_list, (:not_equal, :(.!=)))
 end
 
 for (func, sym) in func_list

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -14,15 +14,12 @@ b = TensorFlow.constant(b_raw)
 @test (a_raw .> b_raw) == run(sess, TensorFlow.greater(a,b))
 @test (a_raw .>= b_raw) == run(sess, TensorFlow.greater_equal(a,b))
 
-
 @test (a_raw .== b_raw) == run(sess, a .== b)
 @test (a_raw .!= b_raw) == run(sess, a .!= b)
 @test (a_raw .< b_raw) == run(sess, a .< b)
 @test (a_raw .<= b_raw) == run(sess, a .<= b)
 @test (a_raw .> b_raw) == run(sess, a .> b)
 @test (a_raw .>= b_raw) == run(sess, a .>= b)
-
-
 
 
 cond = [true; false; true; true; false]

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -14,6 +14,17 @@ b = TensorFlow.constant(b_raw)
 @test (a_raw .> b_raw) == run(sess, TensorFlow.greater(a,b))
 @test (a_raw .>= b_raw) == run(sess, TensorFlow.greater_equal(a,b))
 
+
+@test (a_raw .== b_raw) == run(sess, a .== b)
+@test (a_raw .!= b_raw) == run(sess, a .!= b)
+@test (a_raw .< b_raw) == run(sess, a .< b)
+@test (a_raw .<= b_raw) == run(sess, a .<= b)
+@test (a_raw .> b_raw) == run(sess, a .> b)
+@test (a_raw .>= b_raw) == run(sess, a .>= b)
+
+
+
+
 cond = [true; false; true; true; false]
 cond_tf = TensorFlow.constant(cond)
 result = run(sess, TensorFlow.select(cond_tf, a, b))


### PR DESCRIPTION
https://github.com/malmaud/TensorFlow.jl/commit/bd28eb2e66cf2f0cbff308a0d6d4165e1fa81cb7 broke it I think.

I've added tests for each infix op, so as to be sure they are all imported still.
This might break 0.6
I'll let TravisCI tell me.