### PR TITLE
Implemented Slicing Indexing (inc end)

### DIFF
--- a/src/ops/indexing.jl
+++ b/src/ops/indexing.jl
@@ -103,15 +103,14 @@ function getindex_polyfunction(params::AbstractTensor, indices...)
 end
 
 
-# SLICE_OR_INDEX_TYPES is the types for which getindex_polyfunction was designed
+# Union{Slice, Index} is the types for which getindex_polyfunction was designed
 # Note: need to exclude Bools, because that is in Integer in 0.5
 # This can be a lot cleaner all round in 0.6
-const SLICE_TYPES = Union{TensorRange, UnitRange, Colon}
-const INDEX_TYPES = Union{Int16, Int32, Int64,
+const Slice = Union{TensorRange, UnitRange, Colon}
+const Index = Union{Int16, Int32, Int64,
                           AbstractArray{Int16}, AbstractArray{Int32}, AbstractArray{Int64},
                           Tensor{Int16}, Tensor{Int32}, Tensor{Int64}}
 
-const SLICE_OR_INDEX_TYPES = Union{SLICE_TYPES.types..., INDEX_TYPES.types...}
 
 
 
@@ -121,18 +120,18 @@ function Base.getindex(params::AbstractTensor, indices::Union{Tensor{Bool}, Abst
 end
 
 #For x[[1,2,3]] and x[2] etc
-function Base.getindex(params::AbstractTensor, indices::INDEX_TYPES)
+function Base.getindex(params::AbstractTensor, indices::Index)
     gather(params, indices)
 end
 
 
 # If have one argument, then only use polyfunction if it is a Slice
-function Base.getindex(params::AbstractTensor, ind::SLICE_TYPES)
+function Base.getindex(params::AbstractTensor, ind::Slice)
     getindex_polyfunction(params, ind)
 end
 
 # If have 2+ argument can use the Polyfunction
-function Base.getindex(params::AbstractTensor, ind1::SLICE_OR_INDEX_TYPES, ind2::SLICE_OR_INDEX_TYPES,  inds::Vararg{SLICE_OR_INDEX_TYPES})
+function Base.getindex(params::AbstractTensor, ind1::Union{Slice, Index}, ind2::Union{Slice, Index},  inds::Vararg{Union{Slice, Index}})
     getindex_polyfunction(params, ind1, ind2, inds...)
 end
 

--- a/src/ops/indexing.jl
+++ b/src/ops/indexing.jl
@@ -42,51 +42,100 @@ Base.colon(x,y::Tensor) = colon(Tensor(x), y)
 Base.colon(x::Tensor, y) = colon(x, Tensor(y))
 Base.colon(x::Tensor,y::Tensor) = TensorRange(x,y)
 
-#For x[[1,2,3]] etc
-function Base.getindex(params::AbstractTensor, indices)
-    if eltype(indices) == Bool
-        boolean_mask(params, indices)
-    else
-        gather(params, indices)
-    end
-end
 
-#for slices eg X[1:end] etc
-function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange, UnitRange, Colon}})
-    # This function is all about slices
-
-    # TODO: Assign a name prefix to all the tensors made as art of this section, including constants
+# Mixed Mode Indexing.
+function getindex_polyfunction(params::AbstractTensor, indices...)
     begins = Tensor{Int32}[]
     sizes = Tensor{Int32}[]
+    singleton_dims = Int[]
+
+    function proc_singleton!(ind) #JULIA0.5BUG??. This function needs to be declared here (not mixed with the proc_ind!) or is just doesn't actually get declared. I haven't MWEd it yet
+        # Better be 0D
+        push!(begins, ind)
+        push!(sizes, 1)
+        push!(singleton_dims, length(begins))
+    end
 
     function proc_ind!(ind::Colon)
         push!(begins, 1)
         push!(sizes, -1) # Slice mark for go to end
     end
+
     function proc_ind!(ind::Union{UnitRange, TensorRange})
         #NOTE: end has now been replace with `endof(X)` or `size(X,d)` giving the actual size
         begin_ =  first(ind)
         push!(begins, begin_)
         end_ = last(ind)
-        push!(sizes, end_ - begin_ + 1) # +1 because a slice 3:3 has length 1, and 4:5 has length 3 etc 
+        push!(sizes, end_ - begin_ + 1) # +1 because a slice 3:3 has length 1, and 4:5 has length 3 etc
     end
+
+    function proc_ind!(ind::Tensor)
+        ind_shape = get_shape(ind)
+        if ind_shape.rank_unknown
+            warn("Unknown rank tensor ($ind) used for indexing. Assuming 0D scalar.")
+        elseif length(ind_shape.dims)!=0
+            error("Non-OD scalar used for indexing ($ind). This form of mixed mode indexing is not currently supported.")
+        end
+        proc_singleton!(ind)
+    end
+
+    proc_ind!(ind::Integer) = proc_singleton!(ind)
 
     for ind in indices
         proc_ind!(ind)
     end
 
-    begins_tensor = stack(begins)
-    sizes_tensor = stack(sizes)
-    slice(params, begins_tensor, sizes_tensor)
+    with_op_name("PolyGetIndex") do
+        begins_tensor = stack(begins)
+
+        if length(singleton_dims) == length(begins) #Then we are not slicing any axies
+            gather_nd(params, begins_tensor)
+        else # We are slicing, at some axies
+            sizes_tensor = stack(sizes)
+            sliced = slice(params, begins_tensor, sizes_tensor)
+            if length(singleton_dims)>0 # we are not slicing on all axies
+                squeeze(sliced, singleton_dims) #S queeze singleton indexes
+            else # we are slicing on all axies
+                sliced
+            end
+        end
+    end
 end
 
 
-#For x[1,2,3] etc
-function Base.getindex(params::AbstractTensor, indices...)
-    inds::Vector = collect(indices) # Want Vector, not tuple. Could be a vector of Tensors though
-    if eltype.(inds) ⊆ (Int32, Int64)
-        gather_nd(params, inds)
-    else
-        error("julia style indexing is not currently supported for indicies $indices")
-    end
+# SLICE_OR_INDEX_TYPES is the types for which getindex_polyfunction was designed
+# Note: need to exclude Bools, because that is in Integer in 0.5
+# This can be a lot cleaner all round in 0.6
+const SLICE_TYPES = Union{TensorRange, UnitRange, Colon}
+const INDEX_TYPES = Union{Int16, Int32, Int64,
+                          AbstractArray{Int16}, AbstractArray{Int32}, AbstractArray{Int64},
+                          Tensor{Int16}, Tensor{Int32}, Tensor{Int64}}
+
+const SLICE_OR_INDEX_TYPES = Union{SLICE_TYPES.types..., INDEX_TYPES.types...}
+
+
+
+#For x[[true,false,true]] etc
+function Base.getindex(params::AbstractTensor, indices::Union{Tensor{Bool}, AbstractArray{Bool}})
+    boolean_mask(params, indices)
+end
+
+#For x[[1,2,3]] and x[2] etc
+function Base.getindex(params::AbstractTensor, indices::INDEX_TYPES)
+    gather(params, indices)
+end
+
+
+# If have one argument, then only use polyfunction if it is a Slice
+function Base.getindex(params::AbstractTensor, ind::SLICE_TYPES)
+    getindex_polyfunction(params, ind)
+end
+
+# If have 2+ argument can use the Polyfunction
+function Base.getindex(params::AbstractTensor, ind1::SLICE_OR_INDEX_TYPES, ind2::SLICE_OR_INDEX_TYPES,  inds::Vararg{SLICE_OR_INDEX_TYPES})
+    getindex_polyfunction(params, ind1, ind2, inds...)
+end
+
+function Base.getindex(params::AbstractTensor, inds::Vararg{AbstractTensor})
+    getindex(params, map(Tensor, inds)...)
 end

--- a/src/ops/indexing.jl
+++ b/src/ops/indexing.jl
@@ -1,0 +1,92 @@
+# This code is included into `ops/transformations.jl`
+# These are higher-abstraction transformations about indexing and related functionality
+
+
+"""
+Base.size(n::AbstractTensor; name="")
+Returns the shape of the Tensor.
+WARNING: this does not match the python TensorFlow `size` -- for that functionality, use `Base.length`
+https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#size
+"""
+@op Base.size(n::AbstractTensor; name=nothing) = shape(n; name=name)
+@op Base.size(n::AbstractTensor, i; name=nothing) = shape(n; name=name)[i]
+# size(X, dim) must be implemented for indexing with X[..,end,...] to work
+
+"""
+Base.length(n::AbstractTensor; name="")
+Returns the total number of elements in a Tensor.
+(Like julia `Base.length` does for an `Array`)
+This matchs python TensorFlow `size` operation
+https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#size
+"""
+@op function Base.length(n::AbstractTensor; name=nothing)
+    local desc
+    with_op_name(name, "Size") do
+        desc = NodeDescription("Size")
+        add_input(desc, Tensor(n))
+    end
+    Tensor(Operation(desc), 1)
+end
+@op Base.endof(n::AbstractTensor; name=nothing) = length(n; name=name)
+# endof(X) must be implemented for indexing with X[end] to work
+
+
+immutable TensorRange
+    start::Tensor{Int32}
+    stop::Tensor{Int32}
+end
+Base.first(tr::TensorRange)=tr.start
+Base.last(tr::TensorRange)=tr.stop
+
+Base.colon(x,y::Tensor) = colon(Tensor(x), y)
+Base.colon(x::Tensor, y) = colon(x, Tensor(y))
+Base.colon(x::Tensor,y::Tensor) = TensorRange(x,y)
+
+#For x[[1,2,3]] etc
+function Base.getindex(params::AbstractTensor, indices)
+    if eltype(indices) == Bool
+        boolean_mask(params, indices)
+    else
+        gather(params, indices)
+    end
+end
+
+#for slices eg X[1:end] etc
+function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange, UnitRange, Colon}})
+    # This function is all about slices
+
+    # TODO: Assign a name prefix to all the tensors made as art of this section, including constants
+    begins = Tensor{Int32}[]
+    sizes = Tensor{Int32}[]
+
+    function proc_ind!(ind::Colon)
+        push!(begins, 1)
+        push!(sizes, -1) # Slice mark for go to end
+    end
+    function proc_ind!(ind::Union{UnitRange, TensorRange})
+        #NOTE: end has now been replace with `endof(X)` or `size(X,d)` giving the actual size
+        begin_ =  first(ind)
+        push!(begins, begin_)
+        end_ = last(ind)
+        push!(sizes, end_ - begin_ + 1) # +1 because a slice 3:3 has length 1, and 4:5 has length 3 etc 
+    end
+
+    for ind in indices
+        proc_ind!(ind)
+    end
+
+    begins_tensor = stack(begins)
+    sizes_tensor = stack(sizes)
+    slice(params, begins_tensor, sizes_tensor)
+end
+
+
+#For x[1,2,3] etc
+function Base.getindex(params::AbstractTensor, indices...)
+    inds::Vector = collect(indices) # Want Vector, not tuple. Could be a vector of Tensors though
+    if eltype.(inds) ⊆ (Int32, Int64)
+        gather_nd(params, inds)
+    else
+        error("julia style indexing is not currently supported for indicies $indices")
+    end
+end

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -578,7 +578,7 @@ function Base.getindex(params::AbstractTensor, indices...)
     if eltype.(inds) ⊆ (Int32, Int64)
         gather_nd(params, inds)
     else
-        error("julia style indexing is not currently supported for indicies $inferred")
+        error("julia style indexing is not currently supported for indicies $indices")
     end
 end
 

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -767,7 +767,7 @@ mask = [True, False, True]
 boolean_mask(tensor, mask) ==> [[1, 2], [5, 6]]
 ```
 """
-@op function boolean_mask(tensor, mask; name=nothing)
+@op function boolean_mask(tensor, mask::AbstractTensor; name=nothing)
     local result
     with_op_name(name, "BooleanMask") do
         indices = find(mask)  # TODO generalize to more dimensions
@@ -776,6 +776,17 @@ boolean_mask(tensor, mask) ==> [[1, 2], [5, 6]]
     end
     result
 end
+
+@op function boolean_mask(tensor, mask::AbstractArray; name=nothing)
+    local result
+    with_op_name(name, "BooleanMask") do
+        indices = find(mask)  # TODO generalize to more dimensions
+        result = tensor[indices]
+    end
+    result
+end
+
+
 
 """
 `transpose(n::AbstractTensor, perm=nothing)`

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -522,14 +522,14 @@ end
 
 # Colon promotion rules -- mostly this will make Ints into constants
 immutable TensorRange
-    start::Tensor
-    stop::Tensor
+	start::Tensor{Int32}
+	stop::Tensor{Int32}
 end
 Base.first(tr::TensorRange)=tr.start
 Base.last(tr::TensorRange)=tr.stop
 
 Base.colon(x,y::Tensor) = colon(Tensor(x), y)
-Base.colon(x::AbstractTensor, y) = colon(Tensor(x), Tensor(y)) #HACK brake symetry by using AbstractTensor for 1 and Tensor for the other
+Base.colon(x::Tensor, y) = colon(x, Tensor(y))
 Base.colon(x::Tensor,y::Tensor) = TensorRange(x,y)
 
 #For x[[1,2,3]] etc
@@ -547,18 +547,18 @@ function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange
     # NOTE: slice is still 0 based for begins
 
     # TODO: Assign a name prefix to all the tensors made as art of this section, including constants
-    begins = Tensor[]
-    sizes = Tensor[]
+	begins = Tensor{Int32}[]
+	sizes = Tensor{Int32}[]
 
     function proc_ind!(ind::Colon)
-        push!(begins, Int32(0))
-        push!(sizes, Int32(-1)) # Slice mark for go to end
+		push!(begins, 0)
+		push!(sizes, -1) # Slice mark for go to end
     end
     function proc_ind!(ind::Union{UnitRange, TensorRange})
         #NOTE: end has now been replace with `endof(X)` or `size(X,d)` giving the actual size
-        begin_ =  convert_number(Int32, first(ind) - Int32(1))
+		begin_ =  first(ind) - 1
         push!(begins, begin_)
-        end_ = convert_number(Int32, last(ind))
+        end_ = last(ind)
         push!(sizes, end_ - begin_)
     end
 

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -522,8 +522,8 @@ end
 
 # Colon promotion rules -- mostly this will make Ints into constants
 immutable TensorRange
-	start::Tensor{Int32}
-	stop::Tensor{Int32}
+    start::Tensor{Int32}
+    stop::Tensor{Int32}
 end
 Base.first(tr::TensorRange)=tr.start
 Base.last(tr::TensorRange)=tr.stop
@@ -547,16 +547,16 @@ function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange
     # NOTE: slice is still 0 based for begins
 
     # TODO: Assign a name prefix to all the tensors made as art of this section, including constants
-	begins = Tensor{Int32}[]
-	sizes = Tensor{Int32}[]
+    begins = Tensor{Int32}[]
+    sizes = Tensor{Int32}[]
 
     function proc_ind!(ind::Colon)
-		push!(begins, 0)
-		push!(sizes, -1) # Slice mark for go to end
+        push!(begins, 0)
+        push!(sizes, -1) # Slice mark for go to end
     end
     function proc_ind!(ind::Union{UnitRange, TensorRange})
         #NOTE: end has now been replace with `endof(X)` or `size(X,d)` giving the actual size
-		begin_ =  first(ind) - 1
+        begin_ =  first(ind) - 1
         push!(begins, begin_)
         end_ = last(ind)
         push!(sizes, end_ - begin_)

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -422,34 +422,6 @@ https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#rank
     Tensor(Operation(desc), 1)
 end
 
-"""
-Base.size(n::AbstractTensor; name="")
-Returns the shape of the Tensor.
-WARNING: this does not match the python TensorFlow `size` -- for that functionality, use `Base.length`
-Returns the total number of elements in a Tensor.W
-(Like julia `Base.length` does for an `Array`)
-https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#size
-"""
-@op Base.size(n::AbstractTensor; name=nothing) = shape(n; name=name)
-@op Base.size(n::AbstractTensor, i; name=nothing) = shape(n; name=name)[i]
-# size(X, dim) must be implemented for indexing with X[..,end,...] to work
-
-"""
-Base.length(n::AbstractTensor; name="")
-Returns the total number of elements in a Tensor.
-This matchs python TensorFlow `size` operation
-https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#size
-"""
-@op function Base.length(n::AbstractTensor; name=nothing)
-    local desc
-    with_op_name(name, "Size") do
-        desc = NodeDescription("Size")
-        add_input(desc, Tensor(n))
-    end
-    Tensor(Operation(desc), 1)
-end
-@op Base.endof(n::AbstractTensor; name=nothing) = length(n; name=name)
-# endof(X) must be implemented for indexing with X[end] to work
 
 """
 tile(input, multiples; name="")
@@ -517,69 +489,6 @@ https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#pad
     # TODO pay attention to mode
     mode != "CONSTANT" && warn("pad does not yet pay attention to mode")
     Tensor(Operation(desc))
-end
-
-
-# Colon promotion rules -- mostly this will make Ints into constants
-immutable TensorRange
-    start::Tensor{Int32}
-    stop::Tensor{Int32}
-end
-Base.first(tr::TensorRange)=tr.start
-Base.last(tr::TensorRange)=tr.stop
-
-Base.colon(x,y::Tensor) = colon(Tensor(x), y)
-Base.colon(x::Tensor, y) = colon(x, Tensor(y))
-Base.colon(x::Tensor,y::Tensor) = TensorRange(x,y)
-
-#For x[[1,2,3]] etc
-function Base.getindex(params::AbstractTensor, indices)
-    if eltype(indices) == Bool
-        boolean_mask(params, indices)
-    else
-        gather(params, indices)
-    end
-end
-
-#for slices eg X[1:end] etc
-function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange, UnitRange, Colon}})
-    # This function is all about slices
-    # NOTE: slice is still 0 based for begins
-
-    # TODO: Assign a name prefix to all the tensors made as art of this section, including constants
-    begins = Tensor{Int32}[]
-    sizes = Tensor{Int32}[]
-
-    function proc_ind!(ind::Colon)
-        push!(begins, 0)
-        push!(sizes, -1) # Slice mark for go to end
-    end
-    function proc_ind!(ind::Union{UnitRange, TensorRange})
-        #NOTE: end has now been replace with `endof(X)` or `size(X,d)` giving the actual size
-        begin_ =  first(ind) - 1
-        push!(begins, begin_)
-        end_ = last(ind)
-        push!(sizes, end_ - begin_)
-    end
-
-    for ind in indices
-        proc_ind!(ind)
-    end
-
-    begins_tensor = stack(begins)
-    sizes_tensor = stack(sizes)
-    slice(params, begins_tensor, sizes_tensor)
-end
-
-
-#For x[1,2,3] etc
-function Base.getindex(params::AbstractTensor, indices...)
-    inds::Vector = collect(indices) # Want Vector, not tuple. Could be a vector of Tensors though
-    if eltype.(inds) ⊆ (Int32, Int64)
-        gather_nd(params, inds)
-    else
-        error("julia style indexing is not currently supported for indicies $indices")
-    end
 end
 
 
@@ -934,3 +843,5 @@ end
 end
 
 Base.ctranspose(n::AbstractTensor) = transpose(n)
+
+include("indexing.jl")

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -566,8 +566,8 @@ function Base.getindex(params::AbstractTensor, indices::Vararg{Union{TensorRange
         proc_ind!(ind)
     end
 
-    begins_tensor = pack(begins)
-    sizes_tensor = pack(sizes)
+    begins_tensor = stack(begins)
+    sizes_tensor = stack(sizes)
     slice(params, begins_tensor, sizes_tensor)
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -42,13 +42,9 @@ function Base.show(io::IO, n::Operation)
     print(io, "<Operation '$(node_name(n))'>")
 end
 
-function Base.show(io::IO, t::Tensor)
-    local dtype
-    try
-        dtype = eltype(t)
-    catch
-        dtype = "?"
-    end
+function Base.show{T}(io::IO, t::Tensor{T})
+    @assert T==eltype(t)
+
     s = get_shape(t)
     if s.rank_unknown
         shape = "unknown"
@@ -63,7 +59,7 @@ function Base.show(io::IO, t::Tensor)
         end
         shape = string("(", join(dims, ", "), ")")
     end
-    print(io, "<Tensor $(node_name(t.op)):$(t.value_index) shape=$(shape) dtype=$(dtype)>")
+    print(io, "<Tensor $(node_name(t.op)):$(t.value_index) shape=$(shape) dtype=$(T)>")
 end
 
 function Base.show(io::IO, desc::tensorflow.NodeDef)

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -100,12 +100,17 @@ mask = constant(mask_jl)
 @test x_jl[2:3, :] ==  run(sess, x[2:3, :])
 @test x_jl[2:end, :] ==  run(sess, x[Int32(2):end, :])
 
+@test w_jl[:,:,:] ==  run(sess, w[:, :, :])
 
 ##Mixed slice with index
 @test x_jl[2, :] ==  run(sess, x[2, :])
 @test x_jl[2, :] ==  run(sess, x[constant(2), :])
 
 @test w_jl[2:4, 3, :] ==  run(sess, w[2:4, 3, :])
+@test w_jl[:, 3, :] ==  run(sess, w[:, 3, :])
+@test w_jl[:, end, :] ==  run(sess, w[:, end, :])
+@test w_jl[1:1, :, :] ==  run(sess, w[1:1, :, :])
+
 
 ### ScatterNd
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -58,8 +58,12 @@ y = constant(y_jl)
 
 ### Mask (bool array)
 
-mask = constant([true, false, true,false])
-@test run(sess, boolean_mask(y,mask))  == run(sess, y[mask]) == [1, 3]
+mask_jl=[true, false, true,false]
+mask = constant(mask_jl)
+@test run(sess, boolean_mask(y,mask)) == [1, 3]
+@test run(sess, y[mask]) == [1, 3]
+@test run(sess, boolean_mask(y,mask_jl)) == [1, 3]
+@test run(sess, y[mask_jl]) == [1, 3]
 
 ### Gather (int/ int array) / Index
 
@@ -96,6 +100,12 @@ mask = constant([true, false, true,false])
 @test x_jl[2:3, :] ==  run(sess, x[2:3, :])
 @test x_jl[2:end, :] ==  run(sess, x[Int32(2):end, :])
 
+
+##Mixed slice with index
+@test x_jl[2, :] ==  run(sess, x[2, :])
+@test x_jl[2, :] ==  run(sess, x[constant(2), :])
+
+@test w_jl[2:4, 3, :] ==  run(sess, w[2:4, 3, :])
 
 ### ScatterNd
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -53,11 +53,12 @@ x_jl = [10x+y for x in 1:5, y in 1:7]
 x = constant(x_jl)
 w_jl = [100x+10y+z for x in 1:5, y in 1:7, z in 1:3]
 w = constant(w_jl)
-y = constant([1, 2, 3])
+y_jl = Int32[1,2,3,4]
+y = constant(y_jl)
 
 ### Mask (bool array)
 
-mask = constant([true, false, true])
+mask = constant([true, false, true,false])
 @test run(sess, boolean_mask(y,mask))  == run(sess, y[mask]) == [1, 3]
 
 ### Gather (int/ int array) / Index
@@ -65,6 +66,12 @@ mask = constant([true, false, true])
 @test ones(Float32, 2, 5) == run(sess, gather(one_tens, [1, 2]))
 @test run(sess, y[[1, 3]]) == [1, 3]
 @test run(sess, y[2]) == 2
+
+@test y_jl[end] == run(sess, y[end])
+@test y_jl[end-1] == run(sess, y[end-1])
+@test y_jl[end-2] == run(sess, y[end-2])
+@test y_jl[end÷2] == run(sess, y[end/2])
+@test y_jl[end-y_jl[1]] == run(sess, y[end-y[1]])
 
 ### Gather-nd / Cartean Index/Slice
 @test run(sess, gather_nd(x, [2, 3])) == x_jl[2,3]
@@ -79,6 +86,16 @@ mask = constant([true, false, true])
 ### Slice
 # to do make sure we slice the right indices
 @test ones(Float32, 5).' == run(sess, TensorFlow.slice(one_tens, [1, 1], [1, -1]))
+
+@test y_jl[2:3] ==  run(sess, y[2:3])
+@test y_jl[2:end] ==  run(sess, y[Int32(2):end])
+@test y_jl[2:end] ==  run(sess, y[2:end])
+@test y_jl[:] ==  run(sess, y[:])
+
+@test x_jl[2:3, :] ==  run(sess, x[Int32(2):Int32(3), :])
+@test x_jl[2:3, :] ==  run(sess, x[2:3, :])
+@test x_jl[2:end, :] ==  run(sess, x[Int32(2):end, :])
+
 
 ### ScatterNd
 


### PR DESCRIPTION
This PR beings support for slice indexing for `getindex`
Eg `X[1:3,:, 8:end]`

It does not bring the mixed-mode indexing.
though I am starting to have more and more notions of how that would be done.

This is a breaking change as it redefines `Base.length` to do the `Size` op, and `Base.size` to do the `shape` op.

This is, effectively also the strong counter arguement to not-doing https://github.com/malmaud/TensorFlow.jl/issues/102
though now with dynamic `shape`, rather than static `get_shape`

It is required as like `endof(X)` is in linear indexing,
`size(X,dim)` is required in cartesean indexing 


Technically could define `size(X,dim)` without defining `size(X)` to match, but i feel that is more uninituitive, than any other option.
This is requires because it is hardcoded to replace `end` during parsing (lowering?)
https://github.com/JuliaLang/julia/blob/75c2e72c505be06e1f80498d3746a62a4f239237/src/julia-syntax.scm#L104


CrossRef, what is going on for indexing upstream / in python.
https://github.com/tensorflow/tensorflow/issues/206

Do review this carefully.
I expect it needs some style changes still.
and also it does change things in a few more places than may be expected so might have broken something.

I think a refactor of the usage of  `Int32` vs `cast` vs `convert_number` vs `convert(Int32,..)`
for the  whole code base is in oder