### PR TITLE
Make Scatter_ND enforce type of index/shape

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -675,9 +675,9 @@ rank-3 tensor with two matrices of new values.
     local desc
     with_op_name(name, "ScatterNd") do
         desc = NodeDescription("ScatterNd")
-        add_input(desc, Tensor(convert_number(Int32, indices-Int32(1))))
-        add_input(desc, Tensor(updates))
-        add_input(desc, Tensor(convert_number(Int32, (shape))))  # Must be same type as indicies
+		add_input(desc, convert(Tensor{Int32}, indices-1))
+		add_input(desc, Tensor(updates))
+		add_input(desc, convert(Tensor{Int32}, shape))  # Must be same type as indicies
     end
     Tensor(Operation(desc), 1)
 end

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -675,9 +675,9 @@ rank-3 tensor with two matrices of new values.
     local desc
     with_op_name(name, "ScatterNd") do
         desc = NodeDescription("ScatterNd")
-        add_input(desc, convert_number(Int32, Tensor(indices)-Int32(1)))
+        add_input(desc, Tensor(convert_number(Int32, indices-Int32(1))))
         add_input(desc, Tensor(updates))
-        add_input(desc, Tensor(shape))
+        add_input(desc, Tensor(convert_number(Int32, (shape))))  # Must be same type as indicies
     end
     Tensor(Operation(desc), 1)
 end

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -675,7 +675,7 @@ rank-3 tensor with two matrices of new values.
     local desc
     with_op_name(name, "ScatterNd") do
         desc = NodeDescription("ScatterNd")
-        add_input(desc, Tensor(indices)-1)
+        add_input(desc, convert_number(Int32, Tensor(indices)-Int32(1)))
         add_input(desc, Tensor(updates))
         add_input(desc, Tensor(shape))
     end


### PR DESCRIPTION
`Int32`;  `Int32` everywhere.
Everything else is too hard; and honestly not very required.
How often do nets have matrixes that need to be indexed with `Int64`s?
I think many things would break for that already.

