### PR TITLE
Correct default dimension for LSTMCell

### DIFF
--- a/src/ops/rnn_cell.jl
+++ b/src/ops/rnn_cell.jl
@@ -92,7 +92,7 @@ function zero_state(cell::LSTMCell, batch_size, T)
         zeros(Tensor, T, (batch_size, cell.hidden_size)))
 end
 
-function (cell::LSTMCell)(input, state, input_dim=1)
+function (cell::LSTMCell)(input, state, input_dim=-1)
     N = get_input_dim(input, input_dim) + cell.hidden_size
     T = eltype(state)
     X = cat(Tensor, 2, input, state.h)


### PR DESCRIPTION
I feel like this was meant to default to -1 rather than 1 ie input_dim=-1.
(rather unexpected break in my code from this change)

regression from 
https://github.com/malmaud/TensorFlow.jl/commit/b7e719742d09c5b1aa66bdb46b6fd68724e71645
