### PR TITLE
Sequence Length for  RNNs working 

### DIFF
--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -176,7 +176,7 @@ all elements but all later dimensions may vary.
     num_steps = convert(Tensor{Int64}, tf.shape(inputs)[2])
 
     while_output = @tf while time_step ≤ num_steps
-        slice_start = tf.stack([0, time_step-1, 0])
+        slice_start = tf.stack([1, time_step, 1])
         slice_size = tf.stack([-1, 1, -1])
         data = tf.slice(inputs, slice_start, slice_size)
         data = tf.squeeze(data, [2])

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -145,7 +145,7 @@ Args:
 * `cell`: An instance of `RNNCell`.
 * `inputs`: A `Tensor` of shape `[max_time, batch_size, ..., ...]` or `[batch_size, max_time, ..., ...]` (see `time_major`). May also be a nested `Tuple` with the same property. The first two dimensions *must* be the same across
 all elements but all later dimensions may vary.
-* `sequence_length`: Specifies length of each sequence in `inputs`. se
+* `sequence_length`: Specifies length of each sequence in `inputs`.
 * `initial_state`: A starting state for the RNN. If not provided, the initial state is `zero_state`.
 * `dtype`: Data type of the initial state and output, in case it cannot be inferred.
 * `parallel_iterations`: Number of iterations to run in parallel, defaulting to `32`. Ops that have no temporal dependency can be run in parallel and will be. Trades time for space - larger values use more memory.
@@ -157,20 +157,21 @@ all elements but all later dimensions may vary.
     #TODO Make this all work with non-3D inputs
 
     if time_major
-        inputs=permutedims([2,1,3])
+        inputs=permutedims(inputs, [2,1,3])
     end
+
+    batch_size = get_shape(inputs, 1)
 
     if initial_state === nothing
         if dtype === nothing
             error("dtype must be set if initial_state is not provided")
         end
-        batch_size = get_shape(inputs, 1)
         initial_state = zero_state(cell, batch_size, dtype)
     end
 
     state = initial_state
     input_dim = get_shape(inputs, 3)
-    output = tf.zeros(Tensor{eltype(state)}, get_shape(inputs, 1), output_size(cell))
+    output = tf.zeros(Tensor{eltype(state)}, batch_size, output_size(cell))
 
     time_step = tf.constant(1)
     num_steps = convert(Tensor{Int64}, tf.shape(inputs)[2])

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -195,7 +195,7 @@ all elements but all later dimensions may vary.
 
         variable_scope(scope) do
             new_output, new_state = cell(data, state, input_dim)
-            if sequence_length !== nothing) # This branch should be removed by the julia lowering process
+            if sequence_length !== nothing # This branch should be removed by the julia lowering process
                 # Only update output and state for rows that are not yet passed their ends
                 have_passed_end = sequence_length .< time_step
                 new_output = select(have_passed_end, output, new_output)

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -188,8 +188,8 @@ all elements but all later dimensions may vary.
 
         variable_scope(scope) do
             new_output, new_state = cell(data, state, input_dim)
-            if !isa(sequence_length, Void) #This should be removed by the julia lowering process
-                #Only update output and state for rows that are not yet passed their ends
+            if sequence_length !== nothing) # This branch should be removed by the julia lowering process
+                # Only update output and state for rows that are not yet passed their ends
                 have_passed_end = sequence_length .< time_step
                 new_output = select(have_passed_end, output, new_output)
                 new_state = select(have_passed_end, state, new_state)

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -1,32 +1,57 @@
 using TensorFlow
 using Base.Test
 
-## conv2d_transpose
-let
-    sess = Session(Graph())
-    value = placeholder(Float32, shape=[32, 10, 10, 3])
-    filter = placeholder(Float32, shape=[3, 3, 5, 3])
-    shape_ = placeholder(Int32, shape=[4])
-    y = nn.conv2d_transpose(value, filter, shape_, [1, 1, 1, 1])
-    run(sess, y, Dict(value=>randn(Float32, 32, 10, 10, 3),
-                      filter=>randn(Float32, 3, 3, 5, 3),
-                      shape_=>[32,10,10,5]))
+@testset "conv2d_transpose" begin
+    let
+        sess = Session(Graph())
+        value = placeholder(Float32, shape=[32, 10, 10, 3])
+        filter = placeholder(Float32, shape=[3, 3, 5, 3])
+        shape_ = placeholder(Int32, shape=[4])
+        y = nn.conv2d_transpose(value, filter, shape_, [1, 1, 1, 1])
+        run(sess, y, Dict(value=>randn(Float32, 32, 10, 10, 3),
+                          filter=>randn(Float32, 3, 3, 5, 3),
+                          shape_=>[32,10,10,5]))
+    end
 end
 
-## dynamic_rnn
-
-let
-    sess = Session(Graph())
-    data = constant(ones(1, 2, 1))
-    cell = nn.rnn_cell.BasicRNNCell(1)
-    s0 = nn.zero_state(cell, 1, Float64)
-    local y
-    variable_scope("rnn", initializer=ConstantInitializer(.1)) do
-        y = nn.dynamic_rnn(cell, data, initial_state=s0)
+@testset "dynamic_rnn" begin
+    let
+        sess = Session(Graph())
+        data = constant(ones(1, 2, 1))
+        cell = nn.rnn_cell.BasicRNNCell(1)
+        s0 = nn.zero_state(cell, 1, Float64)
+        local y
+        variable_scope("rnn", initializer=ConstantInitializer(.1)) do
+            y = nn.dynamic_rnn(cell, data, initial_state=s0)
+        end
+        # Disable until the flakiness of the test is resolved
+        # run(sess, global_variables_initializer())  # This is flakily failing.
+        # output = run(sess, y)[1]
+        # expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
+        # @test output[1,1] ≈ expected_output
     end
-    # Disable until the flakiness of the test is resolved
-    # run(sess, global_variables_initializer())  # This is flakily failing.
-    # output = run(sess, y)[1]
-    # expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
-    # @test output[1,1] ≈ expected_output
+end
+
+"Dummy cell for testing, always gives back its input"
+immutable IdentityRNNCell <: nn.rnn_cell.RNNCell
+    input_and_output_size::Int64
+end
+(cell::IdentityRNNCell)(input, state, input_dim=-1) = [input, input]
+TensorFlow.nn.rnn_cell.state_size(c::IdentityRNNCell)=c.input_and_output_size
+TensorFlow.nn.rnn_cell.output_size(c::IdentityRNNCell)=c.input_and_output_size
+
+
+@testset "dynamic_rnn sequence_length" begin
+    let
+        sess = Session(Graph())
+        data_jl = Float32[100*x+10y+z for x in 1:10, y in 1:20, z in 1:10]
+        data = constant(data_jl)
+        lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
+        lens = constant(lens_jl)
+        cell = IdentityRNNCell(10)
+        y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32)
+        run(sess, global_variables_initializer())
+        y_o = run(sess, y)
+        @test y_o == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
+    end
 end

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -18,59 +18,66 @@ const FLAKEY_TESTS_ENABLED = !haskey(ENV,"TRAVIS_JULIA_VERSION")
     end
 end
 
-@testset "dynamic_rnn" begin
-    let
-        sess = Session(Graph())
-        data = constant(ones(1, 2, 1))
-        cell = nn.rnn_cell.BasicRNNCell(1)
-        s0 = nn.zero_state(cell, 1, Float64)
-        local y
-        variable_scope("rnn", initializer=ConstantInitializer(.1)) do
-            y = nn.dynamic_rnn(cell, data, initial_state=s0)
-        end
+for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, identity), (nn.rnn, last))
+    testname = split(string(rnn_fun), ".")[end]
+    @testset "$testname" begin
+        let
+            sess = Session(Graph())
+            data = constant(ones(1, 2, 1))
+            cell = nn.rnn_cell.BasicRNNCell(1)
+            s0 = nn.zero_state(cell, 1, Float64)
+            local y
+            variable_scope("rnn", initializer=ConstantInitializer(.1)) do
+                y = rnn_fun(cell, data, initial_state=s0)
+            end
 
-        if FLAKEY_TESTS_ENABLED
-            run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
-            output = run(sess, y)[1]
-            expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
-            @test output[1,1] ≈ expected_output
-        end
-    end
-end
+            if FLAKEY_TESTS_ENABLED
+                run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
+                outputs = run(sess, y)[1]
+                output = post_proc_outputs(outputs)
 
-
-
-
-@testset "dynamic_rnn sequence_length" begin
-    let
-        sess = Session(Graph())
-        data_jl = Float32[100*x+10y+z for x in 1:10, y in 1:20, z in 1:10]
-        data = constant(data_jl)
-        lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
-        lens = constant(lens_jl)
-        cell = nn.rnn_cell.IdentityRNNCell(10)
-        y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32)
-
-        if FLAKEY_TESTS_ENABLED
-            run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
-            y_o = run(sess, y)
-            @test y_o == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
+                expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
+                @test output[1,1] ≈ expected_output
+            end
         end
     end
 
-    let
-        sess = Session(Graph())
-        data_jl = Float32[100*x+10y+z for x in 1:20, y in 1:10, z in 1:10] #Time first dim, batch second
-        data = constant(data_jl)
-        lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
-        lens = constant(lens_jl)
-        cell = nn.rnn_cell.IdentityRNNCell(10)
-        y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32, time_major=true)
 
-        if FLAKEY_TESTS_ENABLED
-            run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
-            y_o = run(sess, y)
-            @test y_o == [data_jl[lens_jl[xi], xi, zi] for xi in 1:10, zi in 1:10]
+
+
+    @testset "$testname sequence_length" begin
+        let
+            sess = Session(Graph())
+            data_jl = Float32[100*x+10y+z for x in 1:10, y in 1:20, z in 1:10]
+            data = constant(data_jl)
+            lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
+            lens = constant(lens_jl)
+            cell = nn.rnn_cell.IdentityRNNCell(10)
+            y, s_last = rnn_fun(cell, data, lens; dtype=Float32)
+
+            if FLAKEY_TESTS_ENABLED
+                run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
+                outputs = run(sess, y)
+                output = post_proc_outputs(outputs)
+                @test output == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
+            end
+        end
+
+        let
+            sess = Session(Graph())
+            data_jl = Float32[100*x+10y+z for x in 1:20, y in 1:10, z in 1:10] #Time first dim, batch second
+            data = constant(data_jl)
+            lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
+            lens = constant(lens_jl)
+            cell = nn.rnn_cell.IdentityRNNCell(10)
+            y, s_last = rnn_fun(cell, data, lens; dtype=Float32, time_major=true)
+
+            if FLAKEY_TESTS_ENABLED
+                run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
+                outputs = run(sess, y)
+                output = post_proc_outputs(outputs)
+                @test output == [data_jl[lens_jl[xi], xi, zi] for xi in 1:10, zi in 1:10]
+            end
         end
     end
 end

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -48,7 +48,7 @@ end
         data = constant(data_jl)
         lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
         lens = constant(lens_jl)
-        cell = IdentityRNNCell(10)
+        cell = nn.rnn_cell.IdentityRNNCell(10)
         y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32)
 
         if FLAKEY_TESTS_ENABLED
@@ -64,7 +64,7 @@ end
         data = constant(data_jl)
         lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
         lens = constant(lens_jl)
-        cell = IdentityRNNCell(10)
+        cell = nn.rnn_cell.IdentityRNNCell(10)
         y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32, time_major=true)
 
         if FLAKEY_TESTS_ENABLED

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -24,11 +24,11 @@ end
         variable_scope("rnn", initializer=ConstantInitializer(.1)) do
             y = nn.dynamic_rnn(cell, data, initial_state=s0)
         end
-        # Disable until the flakiness of the test is resolved
-        # run(sess, global_variables_initializer())  # This is flakily failing.
-        # output = run(sess, y)[1]
-        # expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
-        # @test output[1,1] ≈ expected_output
+
+        run(sess, global_variables_initializer())
+        output = run(sess, y)[1]
+        expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
+        @test output[1,1] ≈ expected_output
     end
 end
 

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -25,10 +25,11 @@ end
             y = nn.dynamic_rnn(cell, data, initial_state=s0)
         end
 
-        run(sess, global_variables_initializer())
-        output = run(sess, y)[1]
-        expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
-        @test output[1,1] ≈ expected_output
+        #TODO uncomment out Flaky tests
+        #run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
+        #output = run(sess, y)[1]
+        #expected_output = tanh(1*.1+tanh(1*.1+.1)*.1+.1)
+        #@test output[1,1] ≈ expected_output
     end
 end
 
@@ -50,8 +51,9 @@ TensorFlow.nn.rnn_cell.output_size(c::IdentityRNNCell)=c.input_and_output_size
         lens = constant(lens_jl)
         cell = IdentityRNNCell(10)
         y, s_last = nn.dynamic_rnn(cell, data, lens; dtype=Float32)
-        run(sess, global_variables_initializer())
-        y_o = run(sess, y)
-        @test y_o == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
+        #TODO uncomment out Flaky tests
+        #run(sess, global_variables_initializer()) #This line is flakily breaking on Travis
+        #y_o = run(sess, y)
+        #@test y_o == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
     end
 end


### PR DESCRIPTION
This makes the Sequence Length parameter actually do something for Dynamic RNNs.
Also the time-major parameter, while I was here.

I can't think of a nicer way to do this right now.
Though it does seem to have excessive code duplication.
I didn't want to bring the `isa(sequence_length, Void)`, inside the `@tensorflow`.
As I don't think lowering / specialisation on input types  work there.
(Or indeed that it will work within closures, on parameters of the parent type, at all)