### PR TITLE
Check the sizes of the inputs are compatible with the shapes of the placeholders they fill

### DIFF
--- a/examples/logistic.jl
+++ b/examples/logistic.jl
@@ -20,22 +20,22 @@ y = draw(y_prob)
 
 # Build the model
 sess = Session(Graph())
-@tf begin
-    X = placeholder(Float64, shape=[-1, 50])
-    Y_obs = placeholder(Float64, shape=[-1, 10])
 
-    variable_scope("logisitic_model") do
-        global W = get_variable([50, 10], Float64)
-        global B = get_variable([10], Float64)
-    end
+X = placeholder(Float64, shape=[-1, 50])
+Y_obs = placeholder(Float64, shape=[-1, 10])
 
-    Y=nn.softmax(X*W + B)
-
-    Loss = -reduce_sum(log(Y).*Y_obs)
-    optimizer = train.AdamOptimizer()
-    minimize_op = train.minimize(optimizer, Loss)
-    saver = train.Saver()
+variable_scope("logisitic_model"; initializer=Normal(0, .001)) do
+    global W = get_variable("W", [50, 10], Float64)
+    global B = get_variable("B", [10], Float64)
 end
+
+Y=nn.softmax(X*W + B)
+
+Loss = -reduce_sum(log(Y).*Y_obs)
+optimizer = train.AdamOptimizer()
+minimize_op = train.minimize(optimizer, Loss)
+saver = train.Saver()
+
 # Run training
 run(sess, global_variables_initializer())
 checkpoint_path = mktempdir()

--- a/examples/logistic.jl
+++ b/examples/logistic.jl
@@ -1,3 +1,4 @@
+using TensorFlow
 using Distributions
 
 # Generate some synthetic data
@@ -19,20 +20,22 @@ y = draw(y_prob)
 
 # Build the model
 sess = Session(Graph())
-X = placeholder(Float64, shape=[nothing, 10])
-Y_obs = placeholder(Float64, shape=[100])
+@tf begin
+    X = placeholder(Float64, shape=[-1, 50])
+    Y_obs = placeholder(Float64, shape=[-1, 10])
 
-variable_scope("logisitic_model", initializer=Normal(0, .001)) do
-    global W = get_variable("weights", [50, 10], Float64)
-    global B = get_variable("bias", [10], Float64)
+    variable_scope("logisitic_model") do
+        global W = get_variable([50, 10], Float64)
+        global B = get_variable([10], Float64)
+    end
+
+    Y=nn.softmax(X*W + B)
+
+    Loss = -reduce_sum(log(Y).*Y_obs)
+    optimizer = train.AdamOptimizer()
+    minimize_op = train.minimize(optimizer, Loss)
+    saver = train.Saver()
 end
-
-Y=nn.softmax(X*W + B)
-
-Loss = -reduce_sum(log(Y).*Y_obs)
-optimizer = train.AdamOptimizer()
-minimize_op = train.minimize(optimizer, Loss)
-saver = train.Saver()
 # Run training
 run(sess, global_variables_initializer())
 checkpoint_path = mktempdir()

--- a/src/core.jl
+++ b/src/core.jl
@@ -152,9 +152,15 @@ function TensorShape(dims::Vector)
     TensorShape([x<0 ? Nullable{Int64}() : Nullable{Int64}(x) for x in dims])
 end
 
-function TensorShape(dim::Void)
+function TensorShape(::typeof(collect(tuple())))
+    TensorShape(Nullable{Int}[], false)
+end
+
+
+function TensorShape(::Void)
     TensorShape(Nullable{Int}[], true)
 end
+
 
 function get_shape end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -152,7 +152,7 @@ function TensorShape(dims::Vector)
     TensorShape([x<0 ? Nullable{Int64}() : Nullable{Int64}(x) for x in dims])
 end
 
-function TensorShape(::typeof(collect(tuple())))
+function TensorShape(::Vector{Union{}}) # NB: `Vector{Union{}} == typeof(collect(tuple())))`
     TensorShape(Nullable{Int}[], false)
 end
 

--- a/test/run.jl
+++ b/test/run.jl
@@ -1,0 +1,37 @@
+using Base.Test
+using TensorFlow
+
+@testset "Placeholder Size Matching" begin
+    sess = Session(Graph())
+    k = placeholder(Float32; shape=[10, 20, 30])
+    m = placeholder(Float32; shape=[10, 20, -1])
+    n = placeholder(Float32)
+    i = placeholder(Int32; shape=[])
+
+    kk=2k
+    mm=2m
+    nn=2n
+    ii=2i
+
+
+    #Should work fine:
+    run(sess, kk, Dict(k=>ones(10, 20, 30)))
+
+    run(sess, mm, Dict(m=>ones(10, 20, 30)))
+    run(sess, mm, Dict(m=>ones(10, 20, 50)))
+
+    run(sess, nn, Dict(n=>ones(10, 20, 30)))
+    run(sess, nn, Dict(n=>ones(10, 20)))
+    run(sess, nn, Dict(n=>1f0))
+
+    run(sess, ii, Dict(i=>1))
+
+    #Should not be allowed
+    @test_throws DimensionMismatch run(sess, kk, Dict(k=>ones(10, 20, 31)))
+    @test_throws DimensionMismatch run(sess, kk, Dict(k=>ones(10, 20)))
+
+    @test_throws DimensionMismatch run(sess, mm, Dict(m=>ones(10, 21, 30)))
+    @test_throws DimensionMismatch run(sess, mm, Dict(m=>ones(10, 20)))
+
+    @test_throws DimensionMismatch run(sess, ii, Dict(i=>[1,2]))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,8 @@ tests = [
     "ops.jl",
     "summary.jl",
     "nn.jl",
-    "sequences.jl"
+    "sequences.jl",
+    "run.jl",
 ]
 
 # @test_nowarn was added in Julia 0.6.


### PR DESCRIPTION
No-one would put the wrong size into a placeholder intensionly.
And we already have mechanisms to allow parts of a placeholder to have flexible sizes.

Putting the wrong sized input can render uses of shape inference incorrect.
So we should not let people do it.