### PR TITLE
`softmax_cross_entropy_with_logits` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 deps/usr
 deps/downloads
+deps/miniconda
 src/scratch.jl
 tfdocs
 docs/build
 *.DS_Store
+*.*~

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -21,6 +21,7 @@ state_saving_rnn,
 bidirectional_rnn,
 sigmoid_cross_entropy_with_logits,
 sparse_softmax_cross_entropy_with_logits,
+softmax_cross_entropy_with_logits,
 log_softmax,
 embedding_lookup,
 top_k,
@@ -261,6 +262,52 @@ end
         out = -logits.*targets + log(1+ exp(logits))
     end
     out
+end
+
+
+"""
+`softmax_cross_entropy_with_logits(logits, labels, name=None)`
+
+Computes softmax cross entropy between `logits` and `labels`.
+
+Measures the probability error in discrete classification tasks in which the
+classes are mutually exclusive (each entry is in exactly one class).  For
+example, each CIFAR-10 image is labeled with one and only one label: an image
+can be a dog or a truck, but not both.
+
+**NOTE:**  While the classes are mutually exclusive, their probabilities
+need not be.  All that is required is that each row of `labels` is
+a valid probability distribution.  If they are not, the computation of the
+gradient will be incorrect.
+
+If using exclusive `labels` (wherein one and only
+one class is true at a time), see `sparse_softmax_cross_entropy_with_logits`.
+
+**WARNING:** This op expects unscaled logits, since it performs a `softmax`
+on `logits` internally for efficiency.  Do not call this op with the
+output of `softmax`, as it will produce incorrect results.
+
+`logits` and `labels` must have the same shape `[batch_size, num_classes]`
+and the same dtype (either `float32` or `float64`).
+
+##### Args:
+*  <b>`logits`</b>: Unscaled log probabilities.
+*  <b>`labels`</b>: Each row `labels[i]` must be a valid probability distribution.
+*  <b>`name`</b>: A name for the operation (optional).
+
+##### Returns:
+
+  A 1-D `Tensor` of length `batch_size` of the same type as `logits` with the
+  softmax cross entropy loss.
+"""
+@op function softmax_cross_entropy_with_logits(;logits=nothing, labels=nothing, name=nothing)
+    local desc
+    with_op_name(name, "SoftmaxCrossEntropyWithLogits") do
+        desc = NodeDescription("SoftmaxCrossEntropyWithLogits")
+        add_input(desc, logits)
+        add_input(desc, labels)
+    end
+    Tensor(Operation(desc), 1)
 end
 
 """

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -167,6 +167,24 @@ register_shape("SparseSoftmaxCrossEntropyWithLogits") do op
     return [TensorShape([s1.dims[1]]), copy(s1)]
 end
 
+register_shape("SoftmaxCrossEntropyWithLogits") do op
+    s1 = _get_shape(get_input(op, 1))
+    s2 = _get_shape(get_input(op, 2))
+    dim = Nullable{Int}()
+    if !s1.rank_unknown
+        dim = s1.dims[1]
+    end
+    if !s2.rank_unknown && !isnull(s2.dims[1])
+        if isnull(dim)
+            dim = s2.dims[1]
+        else
+            get(dim) == get(s2.dims[1]) || throw(DimensionMismatch("Tensors have incompatiable shapes ($(s1) vs $(s2))"))
+        end
+    end
+
+    return [TensorShape([dim])]
+end
+
 # Binary functions that broadcast
 for func in ["Add", "Sub", "Mul", "Div", "Pow", "SquaredDifference", "Less",
              "LessEqual", "Greater", "GreaterEqual", "Equal", "NotEqual"]

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -14,6 +14,27 @@ using Base.Test
     end
 end
 
+
+@testset "Cross Entropy Loss" begin
+    srand(1)
+    let
+        sess = Session(Graph())
+        targets = constant(collect(1:10))
+        targets_hot = constant(Float64.(eye(10)))
+        logits_unscaled = constant(rand(10,10))
+
+
+        logits = nn.softmax(logits_unscaled)
+        loss_direct = -reduce_sum(log(logits).*targets_hot; axis=1)
+        loss_sparse = nn.sparse_softmax_cross_entropy_with_logits(logits=logits_unscaled, labels=targets)
+        loss_nonsparse = nn.softmax_cross_entropy_with_logits(logits=logits_unscaled, labels=targets_hot)
+        res_direct, res_sparse, res_nonsparse =  run(sess, [loss_direct, loss_sparse, loss_nonsparse])
+
+        @test res_direct ≈ res_sparse
+        @test res_direct ≈ res_nonsparse
+    end
+end
+
 for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, identity), (nn.rnn, last))
     testname = split(string(rnn_fun), ".")[end]
     @testset "$testname" begin

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -7,120 +7,132 @@ n = placeholder(Float32)
 i = placeholder(Int32; shape=[])
 
 
+@testset "placeholder" begin
+    @test get_shape(k) == TensorShape([10, 20, -1])
+    @test get_shape(m) == TensorShape([10, 20, 30])
+    @test get_shape(n) == TensorShape(nothing)
+    @test get_shape(i) == TensorShape([])
 
-@test get_shape(k) == TensorShape([10, 20, -1])
-@test get_shape(m) == TensorShape([10, 20, 30])
-@test get_shape(n) == TensorShape(nothing)
-@test get_shape(i) == TensorShape([])
-
-@test get_shape(k,2) == 20
-@test_throws ErrorException get_shape(k, 3)
-@test_throws BoundsError get_shape(k, 4)
-@test_throws ErrorException get_shape(n, 1)
-
-## Find (i.e Where)
-@test get_shape(find(placeholder(Bool; shape=[10, 20, 30]))) == TensorShape([-1,3])
-@test get_shape(find(placeholder(Bool; shape=[10, 20, -1]))) == TensorShape([-1,3])
-@test get_shape(find(placeholder(Bool))) == TensorShape(nothing)
-
-## stack
-@test get_shape(stack([m,m,m])) == TensorShape([3, 10, 20, 30])
-@test get_shape(stack([m,m,m],axis=2)) == TensorShape([10, 3, 20, 30])
-@test get_shape(stack([m,k])) == TensorShape([2, 10, 20, 30])
-@test get_shape(stack([k,m])) == TensorShape([2, 10, 20, 30])
-@test get_shape(stack([m,n])) == TensorShape([2, 10, 20, 30])
-@test get_shape(stack([n,n])).rank_unknown
-@test get_shape(stack([k,k])) == TensorShape([2, 10, 20, -1])
-
-## unstack
-for ii in 1:10
-    @test get_shape(unstack(m)[ii]) == TensorShape([20, 30])
+    @test get_shape(k,2) == 20
+    @test_throws ErrorException get_shape(k, 3)
+    @test_throws BoundsError get_shape(k, 4)
+    @test_throws ErrorException get_shape(n, 1)
 end
 
-for ii in 1:20
-    @test get_shape(unstack(k, axis=2)[ii]) == TensorShape([10, -1])
+@testset "Arithmetic" begin
+    @test get_shape(-k) == get_shape(k)
+    @test get_shape(k+1) == get_shape(k)
+    @test get_shape(k-1) == get_shape(k)
+
+    @test get_shape(1+k) == get_shape(k)
+    @test get_shape(1-k) == get_shape(k)
+    @test get_shape(2*k) == get_shape(k)
+
+
+    @test get_shape(m+m) == TensorShape([10, 20, 30])
+    @test get_shape(m+n).rank_unknown
+    @test get_shape(m+k) == TensorShape([10, 20, -1])
 end
 
-for ii in 1:3
-    @test get_shape(unstack(n, num=3)[ii]) == TensorShape(nothing)
+@testset "Find (i.e Where)" begin
+    @test get_shape(find(placeholder(Bool; shape=[10, 20, 30]))) == TensorShape([-1,3])
+    @test get_shape(find(placeholder(Bool; shape=[10, 20, -1]))) == TensorShape([-1,3])
+    @test get_shape(find(placeholder(Bool))) == TensorShape(nothing)
+end
+
+@testset "Stack/Unstack" begin
+    #stack
+    @test get_shape(stack([m,m,m])) == TensorShape([3, 10, 20, 30])
+    @test get_shape(stack([m,m,m],axis=2)) == TensorShape([10, 3, 20, 30])
+    @test get_shape(stack([m,k])) == TensorShape([2, 10, 20, 30])
+    @test get_shape(stack([k,m])) == TensorShape([2, 10, 20, 30])
+    @test get_shape(stack([m,n])) == TensorShape([2, 10, 20, 30])
+    @test get_shape(stack([n,n])).rank_unknown
+    @test get_shape(stack([k,k])) == TensorShape([2, 10, 20, -1])
+
+    ## unstack
+    for ii in 1:10
+        @test get_shape(unstack(m)[ii]) == TensorShape([20, 30])
+    end
+
+    for ii in 1:20
+        @test get_shape(unstack(k, axis=2)[ii]) == TensorShape([10, -1])
+    end
+
+    for ii in 1:3
+        @test get_shape(unstack(n, num=3)[ii]) == TensorShape(nothing)
+    end
+
+
+    ### stack/unstack
+    @test get_shape(stack(unstack(m))) == get_shape(m)
+    @test get_shape(stack(unstack(k))) == get_shape(k)
 end
 
 
-### stack/unstack
-@test get_shape(stack(unstack(m))) == get_shape(m)
-@test get_shape(stack(unstack(k))) == get_shape(k)
 
-
-## Add
-@test get_shape(m+m) == TensorShape([10, 20, 30])
-@test get_shape(m+n).rank_unknown
-@test get_shape(m+k) == TensorShape([10, 20, -1])
-
-## Concat
-@test get_shape(cat(2, m,m)) == TensorShape([10, 40, 30])
-@test get_shape(cat(2, m,k))  == TensorShape([10, 40, 30])
-@test get_shape(cat(2, k,m))  == TensorShape([10, 40, 30])
-@test get_shape(cat(3, m,k))  == TensorShape([10,20, -1])
-
-## GatherNd
-@test get_shape(gather_nd(m, [3])) == TensorShape([20, 30]) #1
-
-@test get_shape(gather_nd(m, [5,6,6])) == TensorShape([]) #3
-@test get_shape(gather_nd(m, [5 6 6])) == TensorShape([1])#1x3
-@test get_shape(gather_nd(m, [5 6 6]')) == TensorShape([3, 20, 30])#3x1
-
-@test get_shape(gather_nd(m, [2 5; 2 6; 2 7])) == TensorShape([3, 30]) #2x3
-@test get_shape(gather_nd(m, [2 2 2; 5 6 7])) == TensorShape([2]) #3x2
-
-@test get_shape(gather_nd(m, [5,6])) == TensorShape([30]) #2
-@test get_shape(gather_nd(m, [5 6]')) == TensorShape([2, 20, 30]) #2x1
-
-@test get_shape(gather_nd(m, reshape([3], (1,1)))) == TensorShape([1, 20, 30]) #1x1
-@test get_shape(gather_nd(m, reshape([3], (1,1,1)))) == TensorShape([1, 1, 20, 30]) #1x1x1
-
-
-## ScatterNd
-@test get_shape(scatter_nd([2], [6], [4])) == TensorShape([4])
-@test get_shape(scatter_nd([5 4 2 8]', [9, 10, 11, 12], [8])) == TensorShape([8])
-@test get_shape(scatter_nd([5 3]', [9 9; 10 10], [6,2])) == TensorShape([6, 2])
-
-
-@test get_shape(scatter_nd([5 3]', [9 9; 10 10], TensorShape([6,2]))) == TensorShape([6, 2])
-
-
-
-## ExpandDims
-@test get_shape(expand_dims(m, 1)) == TensorShape([1, 10, 20, 30])
-@test get_shape(expand_dims(m, 2)) == TensorShape([10, 1, 20, 30])
-@test get_shape(expand_dims(m, 3)) == TensorShape([10, 20, 1, 30])
-@test get_shape(expand_dims(m, 4)) == TensorShape([10, 20, 30, 1])
-@test get_shape(expand_dims(m, 0)) == TensorShape([10, 20, 30, 1])
-@test get_shape(expand_dims(m, -1)) == TensorShape([10, 20, 1, 30])
-@test get_shape(expand_dims(m, i)) == TensorShape([-1, -1, -1, -1])
-@test get_shape(expand_dims(n, 2)) == TensorShape(nothing)
-
-
-## Basic Operations
-@test get_shape(-k) == get_shape(k)
-@test get_shape(k+1) == get_shape(k)
-@test get_shape(k-1) == get_shape(k)
-
-@test get_shape(1+k) == get_shape(k)
-@test get_shape(1-k) == get_shape(k)
-@test get_shape(2*k) == get_shape(k)
-
-## Squeeze
-let
-    x = placeholder(Float64, shape=[5, 1, 4, 1, 3])
-    y = squeeze(x, [2, 4])
-    @test get_shape(y) == TensorShape([5, 4, 3])
+@testset "Concat" begin
+    @test get_shape(cat(2, m,m)) == TensorShape([10, 40, 30])
+    @test get_shape(cat(2, m,k))  == TensorShape([10, 40, 30])
+    @test get_shape(cat(2, k,m))  == TensorShape([10, 40, 30])
+    @test get_shape(cat(3, m,k))  == TensorShape([10,20, -1])
 end
 
-## Slice
-let
-    x = placeholder(Float64, shape=[2, 3])
-    y = TensorFlow.slice(x, [1, 2], [-1, 2])
-    @test get_shape(y) == TensorShape([2, 2])
+
+@testset "GatherNd" begin
+    @test get_shape(gather_nd(m, [3])) == TensorShape([20, 30]) #1
+
+    @test get_shape(gather_nd(m, [5,6,6])) == TensorShape([]) #3
+    @test get_shape(gather_nd(m, [5 6 6])) == TensorShape([1])#1x3
+    @test get_shape(gather_nd(m, [5 6 6]')) == TensorShape([3, 20, 30])#3x1
+
+    @test get_shape(gather_nd(m, [2 5; 2 6; 2 7])) == TensorShape([3, 30]) #2x3
+    @test get_shape(gather_nd(m, [2 2 2; 5 6 7])) == TensorShape([2]) #3x2
+
+    @test get_shape(gather_nd(m, [5,6])) == TensorShape([30]) #2
+    @test get_shape(gather_nd(m, [5 6]')) == TensorShape([2, 20, 30]) #2x1
+
+    @test get_shape(gather_nd(m, reshape([3], (1,1)))) == TensorShape([1, 20, 30]) #1x1
+    @test get_shape(gather_nd(m, reshape([3], (1,1,1)))) == TensorShape([1, 1, 20, 30]) #1x1x1
+end
+
+@testset "ScatterNd" begin
+    @test get_shape(scatter_nd([2], [6], [4])) == TensorShape([4])
+    @test get_shape(scatter_nd([5 4 2 8]', [9, 10, 11, 12], [8])) == TensorShape([8])
+    @test get_shape(scatter_nd([5 3]', [9 9; 10 10], [6,2])) == TensorShape([6, 2])
+
+    @test get_shape(scatter_nd([5 3]', [9 9; 10 10], TensorShape([6,2]))) == TensorShape([6, 2])
+end
+
+
+@testset "ExpandDims" begin
+    @test get_shape(expand_dims(m, 1)) == TensorShape([1, 10, 20, 30])
+    @test get_shape(expand_dims(m, 2)) == TensorShape([10, 1, 20, 30])
+    @test get_shape(expand_dims(m, 3)) == TensorShape([10, 20, 1, 30])
+    @test get_shape(expand_dims(m, 4)) == TensorShape([10, 20, 30, 1])
+    @test get_shape(expand_dims(m, 0)) == TensorShape([10, 20, 30, 1])
+    @test get_shape(expand_dims(m, -1)) == TensorShape([10, 20, 1, 30])
+    @test get_shape(expand_dims(m, i)) == TensorShape([-1, -1, -1, -1])
+    @test get_shape(expand_dims(n, 2)) == TensorShape(nothing)
+end
+
+
+
+
+@testset "Squeeze" begin
+    let
+        x = placeholder(Float64, shape=[5, 1, 4, 1, 3])
+        y = squeeze(x, [2, 4])
+        @test get_shape(y) == TensorShape([5, 4, 3])
+    end
+end
+
+@testset "Slice" begin
+    let
+        x = placeholder(Float64, shape=[2, 3])
+        y = TensorFlow.slice(x, [1, 2], [-1, 2])
+        @test get_shape(y) == TensorShape([2, 2])
+    end
 end
 
 @testset "nn.softmax_cross_entropy_with_logits" begin


### PR DESCRIPTION
Won't be required much longer once the automatic ops are in, I guess.
But till then; here it is.

Also brings in testsets throughout shape_inference