### PR TITLE
[A; B] and [A B] concatenation syntax (#187)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tfdocs
 docs/build
 *.DS_Store
 *.*~
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ run(sess, global_variables_initializer())
 checkpoint_path = mktempdir()
 info("Checkpoint files saved in $checkpoint_path")
 for epoch in 1:100
-    cur_loss, _ = run(sess, vcat(Loss, minimize_op), Dict(X=>x, Y_obs=>y))
+    cur_loss, _ = run(sess, [Loss, minimize_op], Dict(X=>x, Y_obs=>y))
     println(@sprintf("Current loss is %.2f.", cur_loss))
     train.save(saver, sess, joinpath(checkpoint_path, "logistic"), global_step=epoch)
 end

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -221,7 +221,7 @@ end
 Applies ExpandDims to the input Tensors `xs`,
 until they are all the same rank -- which must be at least `min_rank`
 """
-function expand_to_same_ranks(min_rank, xs...)
+function expand_to_same_ranks(min_rank, xs)
     compat_xs = collect(xs)
     @label fix_dims
     for (ii, x) in enumerate(compat_xs)
@@ -251,8 +251,14 @@ such that the resulting concatenated Tensor has rank equal to the
 higher of the highest input rank, or the concatentation dimension (`dim`).
 """
 function Base.cat(dim, xs::AbstractTensor...)
-    compat_xs = expand_to_same_ranks(dim, xs...)
-    concat(compat_xs, dim)
+  with_op_name("Cat") do
+    compat_xs = expand_to_same_ranks(dim, xs)
+    if length(xs)>1
+      concat(compat_xs, dim)
+    else
+      compat_xs[1] # If only one input then, no actual concatentation to be done
+    end
+  end
 end
 
 Base.cat(::Type{Tensor}, dim, values...) = cat(dim, Tensor.(values)...)

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -919,10 +919,4 @@ end
 
 Base.ctranspose(n::AbstractTensor) = transpose(n)
 
-
-
-
-
-
-
 include("indexing.jl")

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -259,29 +259,28 @@ Base.cat(::Type{Tensor}, dim, values...) = cat(dim, Tensor.(values)...)
 
 
 """
-Concatentate along dimension 2
-
-`hcat(a, b)` can also be written `[a b]` etc.
-"""
-Base.hcat(xs::AbstractTensor...) = cat(2, xs...)
-
-
-"""
 Concatentate along dimension 1
 
 `vcat(a, b)` can also be written `[a; b]` etc.
 """
 Base.vcat(xs::AbstractTensor...) = cat(1, xs...)
+# Catch common cases where not all args are Tensors, and convert them
+Base.vcat(x1::AbstractTensor, xs...) = vcat(x1, Tensor.(xs)...)
+Base.vcat(x1, x2::AbstractTensor, xs...) = vcat(Tensor(x1), x2, Tensor.(xs)...)
+Base.vcat(x1::AbstractTensor, x2::AbstractTensor, xs...) = vcat(x1, x2, Tensor.(xs)...)
 
 
+"""
+Concatentate along dimension 2
+
+`hcat(a, b)` can also be written `[a b]` etc.
+"""
+Base.hcat(xs::AbstractTensor...) = cat(2, xs...)
 # Catch common cases where not all args are Tensors, and convert them
 Base.hcat(x1::AbstractTensor, xs...) = hcat(x1, Tensor.(xs)...)
 Base.hcat(x1, x2::AbstractTensor, xs...) = hcat(Tensor(x1), x2, Tensor.(xs)...)
 Base.hcat(x1::AbstractTensor, x2::AbstractTensor, xs...) = hcat(x1, x2, Tensor.(xs)...)
 
-Base.vcat(x1::AbstractTensor, xs...) = vcat(x1, Tensor.(xs)...)
-Base.vcat(x1, x2::AbstractTensor, xs...) = vcat(Tensor(x1), x2, Tensor.(xs)...)
-Base.vcat(x1::AbstractTensor, x2::AbstractTensor, xs...) = vcat(x1, x2, Tensor.(xs)...)
 
 
 """

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -176,6 +176,8 @@ end
     s_jl = rand(); s = constant(s_jl);
 
     @testset "vcat" begin
+        @test c_jl == run(sess4, vcat(c))
+        
         @test [c_jl; d_jl] == run(sess4, [c; d])
         @test [c_jl; d_jl; c_jl] == run(sess4, [c; d; c])
 
@@ -194,6 +196,9 @@ end
   end
 
     @testset "hcat" begin
+        @test a_jl == run(sess4, hcat(a))
+        @test hcat(c_jl) == run(sess4, hcat(c)) #hcat 1D makes it 2D
+
         @test [c_jl c_jl] == run(sess4, [c c])
 
         @test [a_jl b_jl] == run(sess4, [a b])

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -1,6 +1,7 @@
 using TensorFlow
 using Base.Test
 
+
 sess = TensorFlow.Session(TensorFlow.Graph())
 
 one_tens = ones(Tensor, (5,5))
@@ -52,6 +53,8 @@ end
     @test size(run(sess, squeeze(sq_ones,[2]))) == (10,5,1)
     @test_throws TensorFlow.TFException run(sess, squeeze(sq_ones,[1]))
 end
+
+
 
 #######################################################################
 # getindex related methods (getindex overload and the methods behind it)
@@ -129,6 +132,9 @@ end
     @test run(sess, TensorFlow.scatter_nd([5 3]', [9 9; 10 10], [6,2])) == [0 0; 0 0; 10 10; 0 0; 9 9; 0 0]
 end
 
+
+
+
 ###################################################################
 # Tests after this point must provide their own sessions and graphs
 
@@ -156,6 +162,42 @@ end
         @test length(run(sess2, vals)) == 10
     end
 
+end
+
+@testset "Concatenation Syntax" begin
+    srand(37)
+    sess4 = Session(Graph())
+
+    a_jl = rand(10,5); a = constant(a_jl);
+    b_jl = rand(10,5); b = constant(b_jl);
+    c_jl = rand(5)  ; c = constant(c_jl);
+    d_jl = rand(10)  ; d = constant(d_jl);
+
+    s_jl = rand(); s = constant(s_jl);
+
+    @testset "vcat" begin
+        @test [c_jl; d_jl] == run(sess4, [c; d])
+        @test [c_jl; d_jl; c_jl] == run(sess4, [c; d; c])
+
+        @test [a_jl; b_jl] == run(sess4, [a; b])
+
+        @test [s_jl; s_jl] == run(sess4, [s; s])
+        @test [s_jl; s_jl; s_jl] == run(sess4, [s; s; s])
+        @test [s_jl; s_jl; s_jl] == run(sess4, [s; [s; s]])
+
+    end
+
+    @testset "hcat" begin
+        @test [c_jl c_jl] == run(sess4, [c c])
+
+        @test [a_jl b_jl] == run(sess4, [a b])
+        @test [a_jl d_jl] == run(sess4, [a d])
+        @test [a_jl b_jl d_jl] == run(sess4, [a b d])
+
+        @test [s_jl s_jl] == run(sess4, [s s])
+        @test [s_jl s_jl s_jl] == run(sess4, [s s s])
+        @test [s_jl s_jl s_jl] == run(sess4, [s [s s]])
+    end
 end
 
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -6,44 +6,52 @@ sess = TensorFlow.Session(TensorFlow.Graph())
 one_tens = ones(Tensor, (5,5))
 
 @test [1, 2] == run(sess, cast(constant([1.8, 2.2]), Int))
-
 @test ones(25) == run(sess, reshape(one_tens, 25))
-
-
-@test Int32[5,5,1] == run(sess, TensorFlow.shape(stack(split(2, 5, one_tens), axis=1)))
-
-@test ones(Float32, 5,5) == run(sess, stack(unstack(one_tens, num=5)))
-
-@test ones(1,5,5) == run(sess, expand_dims(one_tens, 1))
-@test ones(5,1,5) == run(sess, expand_dims(one_tens, 2))
-@test ones(5,1,5) == run(sess, expand_dims(one_tens, -1))
-@test ones(5,5,1) == run(sess, expand_dims(one_tens, 0))
-
 @test 2 == run(sess, rank(one_tens))
-
 @test ones(10,5) == run(sess, tile(one_tens, [2; 1]))
-
-@test ones(Float32, 4,3) == run(sess, transpose(ones(Tensor, (3, 4))))
-@test ones(Float32, 4,3,2) == run(sess, permutedims(ones(Tensor, (4, 2, 3)), [1, 3, 2]))
-
 @test hcat(ones(Float32, 5,5), zeros(Float32, 5)) == run(sess, pad(one_tens, [0 0; 0 1]))
-
 @test Float32[1.; 0.; 0.; 0.; 0.] == run(sess, one_hot(1, 5))
 
-a = Tensor(collect(1:5))
-result = run(sess, shuffle(a))
-for i in 1:5
-    @test i ∈ result
+
+@testset "Stack/Unstack" begin
+    @test Int32[5,5,1] == run(sess, TensorFlow.shape(stack(split(2, 5, one_tens), axis=1)))
+
+    @test ones(Float32, 5,5) == run(sess, stack(unstack(one_tens, num=5)))
+end
+
+@testset "ExpandDims" begin
+    @test ones(1,5,5) == run(sess, expand_dims(one_tens, 1))
+    @test ones(5,1,5) == run(sess, expand_dims(one_tens, 2))
+    @test ones(5,1,5) == run(sess, expand_dims(one_tens, -1))
+    @test ones(5,5,1) == run(sess, expand_dims(one_tens, 0))
 end
 
 
-# Test `squeeze()` works when given explicit dimensions, fails on incorrect explicit dimensions,
-# and works when given no explicit dimension
-sq_ones = ones(Tensor, (10, 1, 5, 1))
-@test size(run(sess, squeeze(sq_ones))) == (10,5)
-@test size(run(sess, squeeze(sq_ones,[2,4]))) == (10,5)
-@test size(run(sess, squeeze(sq_ones,[2]))) == (10,5,1)
-@test_throws TensorFlow.TFException run(sess, squeeze(sq_ones,[1]))
+
+@testset "Permute Dims" begin
+    @test ones(Float32, 4,3) == run(sess, transpose(ones(Tensor, (3, 4))))
+    @test ones(Float32, 4,3,2) == run(sess, permutedims(ones(Tensor, (4, 2, 3)), [1, 3, 2]))
+end
+
+
+@testset "Shuffle" begin
+    a = Tensor(collect(1:5))
+    result = run(sess, shuffle(a))
+    for i in 1:5
+        @test i ∈ result
+    end
+end
+
+
+@testset "Squeeze" begin
+    # Test `squeeze()` works when given explicit dimensions, fails on incorrect explicit dimensions,
+    # and works when given no explicit dimension
+    sq_ones = ones(Tensor, (10, 1, 5, 1))
+    @test size(run(sess, squeeze(sq_ones))) == (10,5)
+    @test size(run(sess, squeeze(sq_ones,[2,4]))) == (10,5)
+    @test size(run(sess, squeeze(sq_ones,[2]))) == (10,5,1)
+    @test_throws TensorFlow.TFException run(sess, squeeze(sq_ones,[1]))
+end
 
 #######################################################################
 # getindex related methods (getindex overload and the methods behind it)
@@ -56,85 +64,98 @@ w = constant(w_jl)
 y_jl = Int32[1,2,3,4]
 y = constant(y_jl)
 
-### Mask (bool array)
+@testset "Mask (bool array)" begin
+    mask_jl=[true, false, true,false]
+    mask = constant(mask_jl)
+    @test run(sess, boolean_mask(y,mask)) == [1, 3]
+    @test run(sess, y[mask]) == [1, 3]
+    @test run(sess, boolean_mask(y,mask_jl)) == [1, 3]
+    @test run(sess, y[mask_jl]) == [1, 3]
+end
 
-mask_jl=[true, false, true,false]
-mask = constant(mask_jl)
-@test run(sess, boolean_mask(y,mask)) == [1, 3]
-@test run(sess, y[mask]) == [1, 3]
-@test run(sess, boolean_mask(y,mask_jl)) == [1, 3]
-@test run(sess, y[mask_jl]) == [1, 3]
+@testset "Gather (int/ int array) / Index" begin
+    @test ones(Float32, 2, 5) == run(sess, gather(one_tens, [1, 2]))
+    @test run(sess, y[[1, 3]]) == [1, 3]
+    @test run(sess, y[2]) == 2
 
-### Gather (int/ int array) / Index
+    @test y_jl[end] == run(sess, y[end])
+    @test y_jl[end-1] == run(sess, y[end-1])
+    @test y_jl[end-2] == run(sess, y[end-2])
+    @test y_jl[end÷2] == run(sess, y[end/2])
+    @test y_jl[end-y_jl[1]] == run(sess, y[end-y[1]])
 
-@test ones(Float32, 2, 5) == run(sess, gather(one_tens, [1, 2]))
-@test run(sess, y[[1, 3]]) == [1, 3]
-@test run(sess, y[2]) == 2
+end
 
-@test y_jl[end] == run(sess, y[end])
-@test y_jl[end-1] == run(sess, y[end-1])
-@test y_jl[end-2] == run(sess, y[end-2])
-@test y_jl[end÷2] == run(sess, y[end/2])
-@test y_jl[end-y_jl[1]] == run(sess, y[end-y[1]])
+@testset "Gather-nd / Cartean Index/Slice" begin
+    @test run(sess, gather_nd(x, [2, 3])) == x_jl[2,3]
+    @test run(sess, x[2,3]) == x_jl[2,3]
 
-### Gather-nd / Cartean Index/Slice
-@test run(sess, gather_nd(x, [2, 3])) == x_jl[2,3]
-@test run(sess, x[2,3]) == x_jl[2,3]
+    @test run(sess, gather_nd(x, [3])) == x_jl[3,:]
 
-@test run(sess, gather_nd(x, [3])) == x_jl[3,:]
+    @test run(sess, gather_nd(x, [1 1; 2 3])) == [x_jl[1,1], x_jl[2,3]]
+    @test run(sess, gather_nd(x, [1 2]')) == [x_jl[1,:]'; x_jl[2,:]']
+end
 
-@test run(sess, gather_nd(x, [1 1; 2 3])) == [x_jl[1,1], x_jl[2,3]]
-@test run(sess, gather_nd(x, [1 2]')) == [x_jl[1,:]'; x_jl[2,:]']
+@testset "Slice" begin
+    # to do make sure we slice the right indices
+    @test ones(Float32, 5).' == run(sess, TensorFlow.slice(one_tens, [1, 1], [1, -1]))
 
+    @test y_jl[2:3] ==  run(sess, y[2:3])
+    @test y_jl[2:end] ==  run(sess, y[Int32(2):end])
+    @test y_jl[2:end] ==  run(sess, y[2:end])
+    @test y_jl[:] ==  run(sess, y[:])
 
-### Slice
-# to do make sure we slice the right indices
-@test ones(Float32, 5).' == run(sess, TensorFlow.slice(one_tens, [1, 1], [1, -1]))
+    @test x_jl[2:3, :] ==  run(sess, x[Int32(2):Int32(3), :])
+    @test x_jl[2:3, :] ==  run(sess, x[2:3, :])
+    @test x_jl[2:end, :] ==  run(sess, x[Int32(2):end, :])
 
-@test y_jl[2:3] ==  run(sess, y[2:3])
-@test y_jl[2:end] ==  run(sess, y[Int32(2):end])
-@test y_jl[2:end] ==  run(sess, y[2:end])
-@test y_jl[:] ==  run(sess, y[:])
-
-@test x_jl[2:3, :] ==  run(sess, x[Int32(2):Int32(3), :])
-@test x_jl[2:3, :] ==  run(sess, x[2:3, :])
-@test x_jl[2:end, :] ==  run(sess, x[Int32(2):end, :])
-
-@test w_jl[:,:,:] ==  run(sess, w[:, :, :])
-
-##Mixed slice with index
-@test x_jl[2, :] ==  run(sess, x[2, :])
-@test x_jl[2, :] ==  run(sess, x[constant(2), :])
-
-@test w_jl[2:4, 3, :] ==  run(sess, w[2:4, 3, :])
-@test w_jl[:, 3, :] ==  run(sess, w[:, 3, :])
-@test w_jl[:, end, :] ==  run(sess, w[:, end, :])
-@test w_jl[1:1, :, :] ==  run(sess, w[1:1, :, :])
+    @test w_jl[:,:,:] ==  run(sess, w[:, :, :])
+end
 
 
-### ScatterNd
+@testset "Mixed slice with index" begin
+    @test x_jl[2, :] ==  run(sess, x[2, :])
+    @test x_jl[2, :] ==  run(sess, x[constant(2), :])
 
-@test run(sess, TensorFlow.scatter_nd([2], [6], [4])) == [0, 6, 0, 0]
-@test run(sess, TensorFlow.scatter_nd([5 4 2 8]', [9, 10, 11, 12], [8])) == [0, 11, 0, 10, 9, 0, 0, 12]
-@test run(sess, TensorFlow.scatter_nd([5 3]', [9 9; 10 10], [6,2])) == [0 0; 0 0; 10 10; 0 0; 9 9; 0 0]
+    @test w_jl[2:4, 3, :] ==  run(sess, w[2:4, 3, :])
+    @test w_jl[:, 3, :] ==  run(sess, w[:, 3, :])
+    @test w_jl[:, end, :] ==  run(sess, w[:, end, :])
+    @test w_jl[1:1, :, :] ==  run(sess, w[1:1, :, :])
+end
+
+@testset "ScatterNd" begin
+    @test run(sess, TensorFlow.scatter_nd([2], [6], [4])) == [0, 6, 0, 0]
+    @test run(sess, TensorFlow.scatter_nd([5 4 2 8]', [9, 10, 11, 12], [8])) == [0, 11, 0, 10, 9, 0, 0, 12]
+    @test run(sess, TensorFlow.scatter_nd([5 3]', [9 9; 10 10], [6,2])) == [0 0; 0 0; 10 10; 0 0; 9 9; 0 0]
+end
+
+###################################################################
+# Tests after this point must provide their own sessions and graphs
+
+@testset "Making a functioning network: Issue #147" begin
+    # concat
+    let
+        sess3 = Session(Graph())
+        x1 = constant(rand(20,10))
+        x2 = get_variable("x2", (50,10), Float64)
+        xs = concat([x1,x2], 1)
+        cost = reduce_sum(xs)
+        optimizer = train.minimize(train.AdamOptimizer(0.1), cost)
+        run(sess3, global_variables_initializer())
+        @test size(run(sess3, xs)) == (70, 10)
+    end
+    
+    # gather_nd
+    let
+        sess2 = Session(Graph())
+        embs = get_variable("tt2", (10,10), Float64)
+        vals = gather_nd(embs,[2])
+        cost = reduce_sum(vals)
+        optimizer = train.minimize(train.AdamOptimizer(0.1), cost)
+        run(sess2, global_variables_initializer())
+        @test length(run(sess2, vals)) == 10
+    end
+
+end
 
 
-############
-# Check it gather_nd can make a network
-sess2 = Session(Graph())
-embs = get_variable("tt2", (10,10), Float64)
-vals = gather_nd(embs,[2])
-cost = reduce_sum(vals)
-optimizer = train.minimize(train.AdamOptimizer(0.1), cost)
-run(sess2, global_variables_initializer())
-@test length(run(sess2, vals)) == 10
-
-# Check concat can make a network Issue #147
-sess3 = Session(Graph())
-x1 = constant(rand(20,10))
-x2 = get_variable("x2", (50,10), Float64)
-xs = concat([x1,x2], 1)
-cost = reduce_sum(xs)
-optimizer = train.minimize(train.AdamOptimizer(0.1), cost)
-run(sess3, global_variables_initializer())
-@test size(run(sess3, xs)) == (70, 10)

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -198,6 +198,13 @@ end
         @test [s_jl s_jl s_jl] == run(sess4, [s s s])
         @test [s_jl s_jl s_jl] == run(sess4, [s [s s]])
     end
+
+    @testset "nonconcatentating" begin
+        @test [s_jl, s_jl] == run(sess4, [s, s])
+        @test [a_jl, b_jl, c_jl, d_jl] == run(sess4, [a, b, c, d])
+
+    end
+
 end
 
 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -182,10 +182,16 @@ end
         @test [a_jl; b_jl] == run(sess4, [a; b])
 
         @test [s_jl; s_jl] == run(sess4, [s; s])
-        @test [s_jl; s_jl; s_jl] == run(sess4, [s; s; s])
-        @test [s_jl; s_jl; s_jl] == run(sess4, [s; [s; s]])
 
-    end
+        s_jl3 = [s_jl; s_jl; s_jl]
+        @test s_jl3 == run(sess4, [s; s; s])
+        @test s_jl3 == run(sess4, [s; [s; s]])
+        # Promotion
+        @test s_jl3 == run(sess4, [s_jl; s; s])
+        @test s_jl3 == run(sess4, [s; s_jl; s])
+        @test s_jl3 == run(sess4, [s; s; s_jl])
+
+  end
 
     @testset "hcat" begin
         @test [c_jl c_jl] == run(sess4, [c c])
@@ -195,9 +201,16 @@ end
         @test [a_jl b_jl d_jl] == run(sess4, [a b d])
 
         @test [s_jl s_jl] == run(sess4, [s s])
-        @test [s_jl s_jl s_jl] == run(sess4, [s s s])
-        @test [s_jl s_jl s_jl] == run(sess4, [s [s s]])
-    end
+
+         s_jl3 = [s_jl s_jl s_jl]
+        @test s_jl3 == run(sess4, [s s s])
+        @test s_jl3 == run(sess4, [s [s s]])
+        # Promotion
+        @test s_jl3 == run(sess4, [s_jl s s])
+        @test s_jl3 == run(sess4, [s s_jl s])
+        @test s_jl3 == run(sess4, [s s s_jl])
+
+   end
 
     @testset "nonconcatentating" begin
         @test [s_jl, s_jl] == run(sess4, [s, s])


### PR DESCRIPTION
does #187
So that cool.


This could do with some code review (like all code).
It contains a `@goto` which is frowned upon by Dijkstra.
Normally I want to use gotos to break out of nested loops, and then I immediately see that I want to refactor to be using a function and then can use return to breakout.

But this time I want to restart the loop from the beginning
One option would be to use a while loop and manage the index manually
But I don't think that is more readable.

One thing that is still pending is a general way for this to be dispatched to when one or more of the varargs is an `AbstractTensor` and one or more is not (but assumably can be converted).
Right now this is accomplished by specialcasing the first two arguments.
So long as one of the first two arguments is an `AbstractTensor` then it is dispatched to correctly.
I think that covers the vast majority of uses.

Maybe it is worth expanding to first 3? Beyond that doing it manually becomes cumbersome.
I could perhaps workout a metaprogramming loop and do it to the first dozen or so.

----------

Not sure what to do with `hvcat` yet.
I don't really know where it is used.