### PR TITLE
Make RNNs not need batch size to be statically known

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -172,6 +172,9 @@ function TensorShape(::Void)
     TensorShape(Nullable{Int}[], true)
 end
 
+function TensorShape(::Vector{Union{}}) # NB: `Vector{Union{}} == typeof(collect(tuple())))`
+    TensorShape(Nullable{Int}[], false)
+end
 
 function get_shape end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -159,18 +159,14 @@ end
     rank_unknown::Bool
 end
 
-function TensorShape(dims::Vector{Nullable{Int}})
+
+function TensorShape{T<:Integer}(dims::AbstractVector{T})
+    TensorShape([x<0 ? Nullable{Int}() : Nullable{Int}(x) for x in dims])
+end
+
+function TensorShape(dims)
     TensorShape(dims, false)
 end
-
-function TensorShape(dims::Vector)
-    TensorShape([x<0 ? Nullable{Int64}() : Nullable{Int64}(x) for x in dims])
-end
-
-function TensorShape(::Vector{Union{}}) # NB: `Vector{Union{}} == typeof(collect(tuple())))`
-    TensorShape(Nullable{Int}[], false)
-end
-
 
 function TensorShape(::Void)
     TensorShape(Nullable{Int}[], true)

--- a/src/ops/indexing.jl
+++ b/src/ops/indexing.jl
@@ -96,10 +96,16 @@ end
 # This can be a lot cleaner all round in 0.6
 const Slice = Union{TensorRange, UnitRange, Colon}
 const Index = Union{Int16, Int32, Int64,
-                          AbstractArray{Int16}, AbstractArray{Int32}, AbstractArray{Int64},
-                          Tensor{Int16}, Tensor{Int32}, Tensor{Int64}}
+                  AbstractArray{Int16}, AbstractArray{Int32}, AbstractArray{Int64},
+                  Tensor{Int16}, Tensor{Int32}, Tensor{Int64}}
 
-
+const NotAllowed = Union{Float16, Float32, Float64, String, Complex128, Complex64, Complex32,
+                         AbstractArray{Float16}, AbstractArray{Float32}, AbstractArray{Float64},
+                         AbstractArray{String}, AbstractArray{Complex128}, AbstractArray{Complex32},
+                         Tensor{Float16}, Tensor{Float32}, Tensor{Float64}, Tensor{String},
+                         Tensor{Complex128}, Tensor{Complex64}, Tensor{Complex32},
+                         FloatRange
+                        }
 
 
 #For x[[true,false,true]] etc
@@ -125,4 +131,15 @@ end
 
 function Base.getindex(params::AbstractTensor, inds::Vararg{AbstractTensor})
     getindex(params, map(Tensor, inds)...)
+end
+
+# Attempt to catch most of the mis-uses
+# won't catch mixed allowed and nonallowed types
+function Base.getindex(params::AbstractTensor, inds::Vararg{NotAllowed})
+    throw(MethodError(getindex, (params, inds...)))
+end
+
+# No index actually given
+function Base.getindex(params::AbstractTensor)
+    throw(MethodError(getindex, (params,)))
 end

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -102,7 +102,7 @@ all elements but all later dimensions may vary.
 * `time_major`: Shape format for `inputs` and `outputs` `Tensor`s. Determines whether the first dimension of each is `max_time` (`true`) or `batch_size` (`false`, default). `true` is more efficient but is the transpose of most TensorFlow operations.
 * `scope`: `VariableScope` for the subgraph. Defaults to `RNN`.
 """
-@op function dynamic_rnn(cell, inputs, sequence_length=nothing; initial_state=nothing, dtype=nothing, parallel_iterations=nothing, swap_memory=false, time_major=false, scope="RNN")
+function dynamic_rnn(cell, inputs, sequence_length=nothing; initial_state=nothing, dtype=nothing, parallel_iterations=nothing, swap_memory=false, time_major=false, scope="RNN")
     #TODO Make this all work with non-3D inputs
 
     if time_major

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -56,11 +56,7 @@ Args:
 """
 function rnn(cell, inputs::Vector, sequence_length=nothing; initial_state=nothing, dtype=nothing, scope="RNN")
     if initial_state === nothing
-        if dtype === nothing
-            error("dtype must be set if initial_state is not provided")
-        end
-        batch_size = tf.get_shape(first(inputs), 1)
-        initial_state = zero_state(cell, batch_size, dtype)
+        initial_state = zero_state(cell, first(inputs), dtype)
     end
     outputs = tf.Tensor[]
     state = initial_state
@@ -103,36 +99,36 @@ all elements but all later dimensions may vary.
 * `scope`: `VariableScope` for the subgraph. Defaults to `RNN`.
 """
 function dynamic_rnn(cell, inputs, sequence_length=nothing; initial_state=nothing, dtype=nothing, parallel_iterations=nothing, swap_memory=false, time_major=false, scope="RNN")
+    input_dim = get_shape(inputs, 3)
     #TODO Make this all work with non-3D inputs
-
+    
     if time_major
         # TODO Do this in a more efficient way
         inputs=permutedims(inputs, [2,1,3])
     end
 
+    num_steps = convert(Tensor{Int64}, tf.shape(inputs)[2])
     if sequence_length === nothing
         # Works around a bug in upstream TensorFlow's while-loop
         # gradient calculation
-        max_time = convert(tf.Tensor{Int}, size(inputs, 2))
-        sequence_length = max_time
+        sequence_length = num_steps
     end
 
-    batch_size = tf.get_shape(inputs, 1)
 
+    initial_data = inputs[:,1,:]
     if initial_state === nothing
-        if dtype === nothing
-            error("dtype must be set if initial_state is not provided")
-        end
-        initial_state = zero_state(cell, batch_size, dtype)
+        initial_state = zero_state(cell, initial_data, dtype)
     end
-
-    state = initial_state
-    input_dim = tf.get_shape(inputs, 3)
-    output = tf.zeros(tf.Tensor{eltype(state)}, batch_size, output_size(cell))
-
-    time_step = tf.constant(1)
-    num_steps = convert(tf.Tensor{Int64}, tf.shape(inputs)[2])
-
+    # By **MAGIC** these values end up in `while_output` even when num_steps=1
+    
+    # Calculate first output -- we can't trivially default it,
+    # because that would require batch_size to be known statically,
+    # and not having a fixed batch_size is pretty nice.
+    output, state = cell(initial_data, initial_state, input_dim)
+    # By **MAGIC** these values end up in `while_output` eve when num_steps=1
+    # and the while-loop should not logically run
+    
+    time_step = tf.constant(2) #skip the completed first step
     while_output = @tf while time_step ≤ num_steps
         data = inputs[:, time_step, :]
         local new_state
@@ -143,8 +139,6 @@ function dynamic_rnn(cell, inputs, sequence_length=nothing; initial_state=nothin
             new_output, new_state = cell(data, state, input_dim)
             # Only update output and state for rows that are not yet passed their ends
             have_passed_end = sequence_length .< time_step
-            # new_output = select(have_passed_end, output, new_output)
-            # new_state = select(have_passed_end, state, new_state)
             f(old_arg, new_arg) = tf.select(have_passed_end, old_arg, new_arg)
             new_output = tf.struct_map(f, output, new_output)
             new_state = tf.struct_map(f, state, new_state)

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -99,15 +99,15 @@ all elements but all later dimensions may vary.
 * `scope`: `VariableScope` for the subgraph. Defaults to `RNN`.
 """
 function dynamic_rnn(cell, inputs, sequence_length=nothing; initial_state=nothing, dtype=nothing, parallel_iterations=nothing, swap_memory=false, time_major=false, scope="RNN")
-    input_dim = get_shape(inputs, 3)
+    input_dim = tf.get_shape(inputs, 3)
     #TODO Make this all work with non-3D inputs
-    
+
     if time_major
         # TODO Do this in a more efficient way
         inputs=permutedims(inputs, [2,1,3])
     end
 
-    num_steps = convert(Tensor{Int64}, tf.shape(inputs)[2])
+    num_steps = convert(tf.Tensor{Int64}, tf.shape(inputs)[2])
     if sequence_length === nothing
         # Works around a bug in upstream TensorFlow's while-loop
         # gradient calculation

--- a/src/ops/rnn_cell.jl
+++ b/src/ops/rnn_cell.jl
@@ -177,29 +177,27 @@ output_size(cell::GRUCell) = cell.hidden_size
 state_size(cell::GRUCell) = cell.hidden_size
 
 function (cell::GRUCell)(input, state, input_dim=-1)
-    with_op_name("GRUCell") do
-        T = eltype(state)
-        N = get_input_dim(input, input_dim) + cell.hidden_size
-        input = Tensor(input)
-        state = Tensor(state)
-        X = [input state]
-        Wz = get_variable("Wz", [N, cell.hidden_size], T)
-        Wr = get_variable("Wr", [N, cell.hidden_size], T)
-        Wh = get_variable("Wh", [N, cell.hidden_size], T)
-        local Bz, Br, Bh
-        tf.variable_scope("Bias", initializer=tf.ConstantInitializer(0.0)) do
-            # TODO doublecheck python also uses 0 for GRU
-            Bz = get_variable("Bz", [cell.hidden_size], T)
-            Br = get_variable("Br", [cell.hidden_size], T)
-            Bh = get_variable("Bh", [cell.hidden_size], T)
-        end
-        z = sigmoid(X*Wz + Bz)
-        r = sigmoid(X*Wr + Br)
-        X2 = [input state.*r]
-        h = nn.tanh(sigmoid(X2*Wh + Bh))
-        s2 = (1-z).*h + z.*state
-        return [s2, s2]
+    T = eltype(state)
+    N = get_input_dim(input, input_dim) + cell.hidden_size
+    input = Tensor(input)
+    state = Tensor(state)
+    X = [input state]
+    Wz = get_variable("Wz", [N, cell.hidden_size], T)
+    Wr = get_variable("Wr", [N, cell.hidden_size], T)
+    Wh = get_variable("Wh", [N, cell.hidden_size], T)
+    local Bz, Br, Bh
+    tf.variable_scope("Bias", initializer=tf.ConstantInitializer(0.0)) do
+        # TODO doublecheck python also uses 0 for GRU
+        Bz = get_variable("Bz", [cell.hidden_size], T)
+        Br = get_variable("Br", [cell.hidden_size], T)
+        Bh = get_variable("Bh", [cell.hidden_size], T)
     end
+    z = sigmoid(X*Wz + Bz)
+    r = sigmoid(X*Wr + Br)
+    X2 = [input state.*r]
+    h = nn.tanh(sigmoid(X2*Wh + Bh))
+    s2 = (1-z).*h + z.*state
+    return [s2, s2]
 end
 
 type MultiRNNCell <: RNNCell

--- a/src/ops/rnn_cell.jl
+++ b/src/ops/rnn_cell.jl
@@ -12,7 +12,7 @@ IdentityRNNCell
 
 using Compat
 import ....Main: TensorFlow
-import .TensorFlow: Operation, get_shape, get_variable, tanh, Tensor, nn
+import .TensorFlow: Operation, get_shape, get_variable, tanh, Tensor, nn, concat, expand_dims, with_op_name, AbstractTensor
 import .nn: sigmoid
 const tf = TensorFlow
 
@@ -36,13 +36,31 @@ function get_input_dim(input, input_dim)
     end
 end
 
-"""
-Form a `RNNCell` with all states initialized to zero.
-"""
-function zero_state(cell::RNNCell, batch_size, T)
-    zeros(Tensor{T}, batch_size, state_size(cell))
+
+function zero_mat(rows_like::AbstractTensor, n_cols::Integer, dtype)
+    T = dtype===nothing ? eltype(rows_like) : dtype
+    input_shape = get_shape(rows_like)
+    if input_shape.rank_unknown || isnull(input_shape.dims[1])
+        with_op_name("DynZeroMat") do
+            # Cunning trick to (dynamically) make a zero Tensor
+            # without statically knowing the shape of rows_like
+            rhs = zeros(T, 1, n_cols)
+            lhs = tf.slice(rows_like, [1,1], [-1,1]) #i.e. expand_dims(input[:,1], 2)
+            convert(Tensor{T}, lhs*rhs)
+        end
+    else
+        n_rows = get(input_shape.dims[1])
+        zeros(Tensor{T}, n_rows, n_cols)
+    end
 end
 
+"""
+Form a `RNNCell` with all states initialized to zero.
+The first dimention of `input` is used to deterimine the batch_size
+"""
+function zero_state(cell::RNNCell, input, dtype)
+    zero_mat(input, state_size(cell), dtype)
+end
 
 
 """
@@ -90,6 +108,7 @@ end
 
 Base.eltype{C, H}(::Type{LSTMStateTuple{C,H}}) = eltype(C)
 
+
 function tf.get_tensors(s::LSTMStateTuple)
     [s.c, s.h]
 end
@@ -114,16 +133,17 @@ state_size(cell::LSTMCell) = LSTMStateTuple(cell.hidden_size, cell.hidden_size)
 """
 Form a `LSTMCell` with all states initialized to zero.
 """
-function zero_state(cell::LSTMCell, batch_size, T)
-    LSTMStateTuple(zeros(Tensor{T}, batch_size, cell.hidden_size),
-        zeros(Tensor{T}, batch_size, cell.hidden_size))
+function zero_state(cell::LSTMCell, input, T)
+    LSTMStateTuple(zero_mat(input, cell.hidden_size, T),
+        zero_mat(input, cell.hidden_size, T))
 end
+
 
 function (cell::LSTMCell)(input, state, input_dim=-1)
     N = get_input_dim(input, input_dim) + cell.hidden_size
     T = eltype(state)
     input = Tensor(input)
-    X = cat(2, input, state.h)
+    X = [input state.h]
 
     Wi = get_variable("Wi", [N, cell.hidden_size], T)
     Wf = get_variable("Wf", [N, cell.hidden_size], T)
@@ -157,26 +177,29 @@ output_size(cell::GRUCell) = cell.hidden_size
 state_size(cell::GRUCell) = cell.hidden_size
 
 function (cell::GRUCell)(input, state, input_dim=-1)
-    T = eltype(state)
-    N = get_input_dim(input, input_dim) + cell.hidden_size
-    input = Tensor(input)
-    state = Tensor(state)
-    X = cat(2, input, state)
-    Wz = get_variable("Wz", [N, cell.hidden_size], T)
-    Wr = get_variable("Wr", [N, cell.hidden_size], T)
-    Wh = get_variable("Wh", [N, cell.hidden_size], T)
-    local Bz, Br, Bh
-    tf.variable_scope("Bias", initializer=tf.ConstantInitializer(0.0)) do  # TODO doublecheck python also uses 0 for GRU
-        Bz = get_variable("Bz", [cell.hidden_size], T)
-        Br = get_variable("Br", [cell.hidden_size], T)
-        Bh = get_variable("Bh", [cell.hidden_size], T)
+    with_op_name("GRUCell") do
+        T = eltype(state)
+        N = get_input_dim(input, input_dim) + cell.hidden_size
+        input = Tensor(input)
+        state = Tensor(state)
+        X = [input state]
+        Wz = get_variable("Wz", [N, cell.hidden_size], T)
+        Wr = get_variable("Wr", [N, cell.hidden_size], T)
+        Wh = get_variable("Wh", [N, cell.hidden_size], T)
+        local Bz, Br, Bh
+        tf.variable_scope("Bias", initializer=tf.ConstantInitializer(0.0)) do
+            # TODO doublecheck python also uses 0 for GRU
+            Bz = get_variable("Bz", [cell.hidden_size], T)
+            Br = get_variable("Br", [cell.hidden_size], T)
+            Bh = get_variable("Bh", [cell.hidden_size], T)
+        end
+        z = sigmoid(X*Wz + Bz)
+        r = sigmoid(X*Wr + Br)
+        X2 = [input state.*r]
+        h = nn.tanh(sigmoid(X2*Wh + Bh))
+        s2 = (1-z).*h + z.*state
+        return [s2, s2]
     end
-    z = sigmoid(X*Wz + Bz)
-    r = sigmoid(X*Wr + Br)
-    X2 = cat(2, input, state.*r)
-    h = nn.tanh(sigmoid(X2*Wh + Bh))
-    s2 = (1-z).*h + z.*state
-    return [s2, s2]
 end
 
 type MultiRNNCell <: RNNCell
@@ -191,8 +214,8 @@ function state_size(cell::MultiRNNCell)
     map(state_size, cell.cells)
 end
 
-function zero_state(cell::MultiRNNCell, batch_size, T)
-    [zero_state(subcell, batch_size, T) for subcell in cell.cells]
+function zero_state(cell::MultiRNNCell, input, T)
+    [zero_state(subcell, input, T) for subcell in cell.cells]
 end
 
 function (cell::MultiRNNCell)(input, state, input_dim=-1)
@@ -215,7 +238,7 @@ DropoutWrapper(cell; output_keep_prob=1.0) = DropoutWrapper(cell, Tensor(output_
 
 output_size(cell::DropoutWrapper) = output_size(cell.cell)
 state_size(cell::DropoutWrapper) = state_size(cell.cell)
-zero_state(cell::DropoutWrapper, batch_size, T) = zero_state(cell.cell, batch_size, T)
+zero_state(cell::DropoutWrapper, input, T) = zero_state(cell.cell, input, T)
 
 function (wrapper::DropoutWrapper)(input, state, input_dim=-1)
     output, new_state = wrapper.cell(input, state, input_dim)
@@ -223,4 +246,4 @@ function (wrapper::DropoutWrapper)(input, state, input_dim=-1)
     dropped_output, new_state
 end
 
-end
+end #module

--- a/src/ops/sequences.jl
+++ b/src/ops/sequences.jl
@@ -74,9 +74,14 @@ end
     Ops.range(start, length+1, step; kwargs...)
 end
 
-@op function Base.fill(n::AbstractTensor, dims; kwargs...)
+@op function Base.fill(n::AbstractTensor, dims; kwargs...) #TODO: I think this is uncallable in 0.5
     Ops.fill(convert(Tensor{Int32}, [dims...]), n; kwargs...)
 end
+
+@op function Base.fill(n::AbstractTensor, dims::AbstractTensor; kwargs...)
+    Ops.fill(convert(Tensor{Int32}, dims), n; kwargs...)
+end
+
 
 @op function Base.reverse(x::AbstractTensor, indices; kwargs...)
     Ops.reverse_v2(x, indices; kwargs...)

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -113,14 +113,14 @@ such that the resulting concatenated Tensor has rank equal to the
 higher of the highest input rank, or the concatentation dimension (`dim`).
 """
 function Base.cat(dim, xs::AbstractTensor...)
-  with_op_name("Cat") do
-    compat_xs = expand_to_same_ranks(dim, xs)
-    if length(xs)>1
-      concat(compat_xs, dim)
-    else
-      compat_xs[1] # If only one input then, no actual concatentation to be done
+    with_op_name("Cat") do
+        compat_xs = tf_promote(expand_to_same_ranks(dim, xs)...)
+        if length(xs)>1
+             concat(compat_xs, dim)
+        else
+             compat_xs[1] # If only one input then, no actual concatentation to be done
+        end
     end
-  end
 end
 
 Base.cat(::Type{Tensor}, dim, values...) = cat(dim, Tensor.(values)...)

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -389,7 +389,7 @@ Returns:
 end
 
 @op function Base.permutedims(n::AbstractTensor, perm; name=nothing)
-    transpose(n, perm.-1; name=name)
+    transpose(n, perm; name=name)
 end
 
 @define_unary Base.ctranspose transpose

--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -389,7 +389,7 @@ Returns:
 end
 
 @op function Base.permutedims(n::AbstractTensor, perm; name=nothing)
-    transpose(n, perm; name=name)
+    transpose(n, perm - 1; name=name)
 end
 
 @define_unary Base.ctranspose transpose

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -85,9 +85,6 @@ function get_shape(n::tf.AbstractTensor, dim::Integer)
     get(shape.dims[dim])
 end
 
-# Overload `Base.size` so that [3:4, 1:end] etc works
-Base.size(n::tf.AbstractTensor, dim::Integer) = get_shape(n, dim)
-
 function _get_shape(n::tf.AbstractTensor)
     t = Tensor(n)
     cache_key = (t.op.name, t.value_index)

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -209,7 +209,22 @@ for func in ["Add", "Sub", "Mul", "Div", "Pow", "SquaredDifference", "Less",
 end
 
 register_shape("Transpose") do op
-    [TensorShape(reverse(_get_shape(get_input(op, 1)).dims))]
+    input_shape = _get_shape(get_input(op, 1))
+    
+    maybe_reorder = load_const(get_input(op, 2))
+    if isnull(maybe_reorder)
+        [TensorShape(nothing)]
+    else
+        order::Vector{Int32} = get(maybe_reorder) + 1
+        if input_shape.rank_unknown
+            # We know the rank, 
+            # it must be the same as the number of elements in the perm
+            [TensorShape(fill(Nullable{Int32}(), length(order)))]
+        else
+            # Ideal case
+            [TensorShape(input_shape.dims[order])]
+        end
+    end
 end
 
 """
@@ -752,12 +767,15 @@ end
 
 register_shape("Squeeze") do op
     input_shape = _get_shape(get_input(op, 1))
-    squeeze_dims = get_attr(op, "squeeze_dims", Vector{Int})
+    squeeze_dims = get_attr(op, "squeeze_dims", Vector{Int}) + 1
     if input_shape.rank_unknown
         [TensorShape(nothing)]
+    elseif any(squeeze_dims .> length(input_shape.dims))
+        # Workaround https://github.com/JuliaLang/julia/issues/22055
+        throw(BoundsError(input_shape.dims, squeeze_dims))
     else
         new_shape = copy(input_shape)
-        deleteat!(new_shape.dims, squeeze_dims+1)
+        deleteat!(new_shape.dims, squeeze_dims)
         [new_shape]
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,6 +1,16 @@
 using Base.Test
 using TensorFlow
 
+@testset "TensorShape" begin
+    @test TensorShape([]) == TensorShape(Nullable{Int}[],false)
+    @test TensorShape(collect(tuple())) == TensorShape([],false)
+    
+    @test TensorShape([-1, 15]) == TensorShape([Nullable{Int}(), Nullable{Int}(15)], false)
+    @test TensorShape([10, 12]) == TensorShape([Nullable{Int}(10), Nullable{Int}(12)], false)
+
+    @test TensorShape(nothing).rank_unknown == true
+end
+
 @testset "Graph importing" begin
     if tf_version() >= v"1.0.0-rc1"
         graph_pb = read(joinpath(dirname(@__FILE__), "graph.pb"))

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -1,6 +1,7 @@
 using TensorFlow
 using Base.Test
 
+
 @testset "conv2d_transpose" begin
     let
         sess = Session(Graph())
@@ -35,14 +36,57 @@ end
     end
 end
 
-for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, Base.identity), (nn.rnn, last))
+@testset "rnn_cell zero state" begin
+    let
+        sess = Session(Graph())
+        
+        x = placeholder(Float32, shape=[-1, 1, 5])
+        x1 = x[:,1,:]
+        gru_state = nn.rnn_cell.zero_state(nn.rnn_cell.GRUCell(7), x1, nothing)
+        lstm_state = nn.rnn_cell.zero_state(nn.rnn_cell.LSTMCell(7), x1, nothing)
+
+        @test eltype(lstm_state) == Float32
+
+        gru_state_jl, lstm_state_jl = run(sess, [gru_state, lstm_state], Dict(x=>rand(19, 1, 5)))
+
+        @test size(gru_state_jl) == (19, 7) #batchsize, hidden_size
+        @test all(gru_state_jl .== 0f0)
+        @test size(lstm_state_jl.c) == (19, 7) #batchsize, hidden_size
+        @test all(lstm_state_jl.c .== 0f0)
+        @test size(lstm_state_jl.h) == (19, 7) #batchsize, hidden_size
+        @test all(lstm_state_jl.h .== 0f0)
+    end
+end
+
+
+for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, identity), (nn.rnn, last))
     testname = split(string(rnn_fun), ".")[end]
-    @testset "$testname" begin
+
+     @testset "$testname len 1" begin
+        let
+            sess = Session(Graph())
+            data = constant(ones(1, 1, 1))
+            cell = nn.rnn_cell.BasicRNNCell(1)
+            local y
+            variable_scope("rnn", initializer=ConstantInitializer(.1)) do
+                y = rnn_fun(cell, data)
+            end
+
+            run(sess, global_variables_initializer())
+            outputs = run(sess, y)[1]
+            output = post_proc_outputs(outputs)
+
+            expected_output = tanh(1*.1+.1)
+            @test output[1,1] ≈ expected_output
+        end
+    end
+
+    @testset "$testname len2" begin
         let
             sess = Session(Graph())
             data = constant(ones(1, 2, 1))
             cell = nn.rnn_cell.BasicRNNCell(1)
-            s0 = nn.zero_state(cell, 1, Float64)
+            s0 = nn.zero_state(cell, data[:,1,:], Float64)
             local y
             variable_scope("rnn", initializer=ConstantInitializer(.1)) do
                 y = rnn_fun(cell, data, initial_state=s0)
@@ -59,8 +103,6 @@ for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, Base.identity), (nn.rnn, l
     end
 
 
-
-
     @testset "$testname sequence_length" begin
         let
             sess = Session(Graph())
@@ -75,32 +117,32 @@ for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, Base.identity), (nn.rnn, l
             outputs = run(sess, y)
             output = post_proc_outputs(outputs)
             @test output == [data_jl[xi, lens_jl[xi], zi] for xi in 1:10, zi in 1:10]
-
-        end
-
-        let
-            sess = Session(Graph())
-            data_jl = Float32[100*x+10y+z for x in 1:20, y in 1:10, z in 1:10] #Time first dim, batch second
-            data = constant(data_jl)
-            lens_jl = collect(1:2:20) #1 for each element in the batch (x) saying how far to go down the time (y)
-            lens = constant(lens_jl)
-            cell = nn.rnn_cell.IdentityRNNCell(10)
-            y, s_last = rnn_fun(cell, data, lens; dtype=Float32, time_major=true)
-
-            run(sess, global_variables_initializer())
-            outputs = run(sess, y)
-            output = post_proc_outputs(outputs)
-            @test output == [data_jl[lens_jl[xi], xi, zi] for xi in 1:10, zi in 1:10]
         end
     end
+
+    @testset "$testname dynamic batch-size" begin
+        let
+            sess = Session(Graph())
+            
+            x = placeholder(Float32, shape=[-1, 1, 5])
+            cell = nn.rnn_cell.GRUCell(7)
+            out, state = rnn_fun(cell, x)
+            
+            run(sess, global_variables_initializer())
+            outs_jl, state_jl = run(sess, [out, state], Dict(x=>rand(19, 1, 5)))
+            
+            @test size(state_jl) == (19, 7) #batchsize, hidden_size
+        end
+    end
+
+
 end
 
 @testset "rnn gradients" begin
     sess = Session(Graph())
     cell = nn.rnn_cell.LSTMCell(10)
-    s0 = nn.zero_state(cell, 5, Float32)
     inputs = constant(randn(Float32, 5, 32, 5))
-    out = nn.dynamic_rnn(cell, inputs, initial_state=s0)
+    out = nn.dynamic_rnn(cell, inputs)
     loss = reduce_sum(out[1]).^2
     minimizer = train.GradientDescentOptimizer(.01)
     minimize_op = train.minimize(minimizer, loss)

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -18,6 +18,19 @@ i = placeholder(Int32; shape=[])
     @test_throws ErrorException get_shape(n, 1)
 end
 
+@testset "Transpose/Permutedims" begin
+    #Constant propergation in shape_inference is not yet up to the task for this
+    #@test_broken get_shape(k') == get_shape(transpose(k)) == TensorShape([-1, 20, 10])
+    #@test_broken get_shape(m') == get_shape(transpose(m)) == TensorShape([30, 20, 10])
+
+    @test get_shape(n') == get_shape(transpose(n)) == TensorShape(nothing)
+
+    @test get_shape(permutedims(m, [3,1,2])) == TensorShape([30, 10, 20])
+    @test get_shape(permutedims(n, [3,1,2,4])) == TensorShape([-1, -1, -1, -1])
+
+end
+
+
 @testset "Arithmetic" begin
     @test get_shape(-k) == get_shape(k)
     @test get_shape(k+1) == get_shape(k)

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -126,6 +126,12 @@ end
     @test w_jl[1:1, :, :] ==  run(sess, w[1:1, :, :])
 end
 
+@testset "Invalid GetIndex" begin
+    @test_throws MethodError x[]
+    @test_throws MethodError x[1.0:0.5:end]
+    @test_throws MethodError x[1f0]
+end
+
 @testset "ScatterNd" begin
     @test run(sess, TensorFlow.scatter_nd([2], [6], [4])) == [0, 6, 0, 0]
     @test run(sess, TensorFlow.scatter_nd([5 4 2 8]', [9, 10, 11, 12], [8])) == [0, 11, 0, 10, 9, 0, 0, 12]

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -67,6 +67,17 @@ w = constant(w_jl)
 y_jl = Int32[1,2,3,4]
 y = constant(y_jl)
 
+wp = placeholder(Int; shape=[5, -1, -1])
+
+@testset "Size" begin
+    for i in 1:3
+        @test run(sess, size(w,i)) == size(w_jl,i)
+        @test run(sess, size(wp,i), Dict(wp=>w_jl)) == size(w_jl,i)
+    end
+    @test run(sess, size(w)) == collect(size(w_jl))
+    @test run(sess, size(wp), Dict(wp=>w_jl)) == collect(size(w_jl))
+end
+
 @testset "Mask (bool array)" begin
     mask_jl=[true, false, true,false]
     mask = constant(mask_jl)


### PR DESCRIPTION
The main thrust of this PR is to allow the batch_size of a RNN input to be able to be unknown.
So it can be 

for a static RNN eg
```
data = placeholder(Float32; shape=(-1,20, 25)
```

And for a dynamic RNN eg:
```
data = placeholder(Float32; shape=(-1,-1, 25)
```

The PR does a few other things/

 - I found that time-major actually didn't work as a parameter (Might need to add a test for that still, though I have checked it manually)
 - It was too easy to do illegal sliced indexing and get stackoverflows (see https://github.com/MikeInnes/Flux.jl/pull/28#issuecomment-301220635)
 - TensorShape was messing up on a cornercase that showed up in testing Transpose. So I tweaked it and added tests

This could be broken into 4 PR. for commits 2,3,4,(1+5).
Technically, I think they would each work on their own (maybe not 2 without 3).
But I was solving other things as I solved the main goal.
I could cherry pick-them apart if required.