### PR TITLE
be more specific about VERSION cutoffs in ops.jl

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -5,7 +5,7 @@ const tf = TensorFlow # so know where op_funcs is defined
 
 using MacroTools
 
-if VERSION < v"0.6.0-"
+if VERSION < v"0.6.0-dev.1632"
     import Base: .*, .+, ./, .-, .^, .==, .!=
 end
 
@@ -438,7 +438,7 @@ include("ops/queues.jl")
 include("ops/clipping.jl")
 include("ops/init_ops.jl")
 
-if VERSION >= v"0.6-"
+if VERSION >= v"0.6.0-dev.2123"
     include("ops/v6_ops.jl")
 end
 

--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -47,7 +47,7 @@ end
 
 const matmul = mat_mul
 
-@static if VERSION > v"0.6-"  # Cope with changes in broadcasting in Julia 0.6
+@static if VERSION > v"0.6.0-dev.1632"  # Cope with changes in broadcasting in Julia 0.6
     @define_broadcast(*, mul)
     @define_broadcast(+, add)
     @define_broadcast(-, sub)
@@ -116,7 +116,7 @@ end
 
 ^(n::AbstractTensor, x::Int) = invoke(^, Tuple{AbstractTensor, Any}, n, x)
 
-# @static if VERSION < v"0.6-"
+# @static if VERSION < v"0.6.0-dev.1632"
 #     .^(n::AbstractTensor, x) = n^x
 # else
 #     Base.broadcast(::typeof(^), n::AbstractTensor, x) = n^x


### PR DESCRIPTION
avoid breaking the package on early dev versions, in case bisecting
on base is ever needed to isolate a bug triggered by this package