### PR TITLE
Fix the uniform_random used by dropout

### DIFF
--- a/src/ops/sequences.jl
+++ b/src/ops/sequences.jl
@@ -53,8 +53,7 @@ A `Tensor` of the specified `shape` and `dtype` containing random values.
         seed1 = 0
         # TODO use global seed
         seed2 = seed
-        r = random_uniform(shape; seed=seed1, seed2=seed2, dtype=dtype)
-        r
+        r = random_uniform(shape; seed=seed1, seed2=seed2, dtype=dtype, name=name)
         out = r .* (maxval-minval) + minval
     end
     out

--- a/src/ops/sequences.jl
+++ b/src/ops/sequences.jl
@@ -21,7 +21,7 @@ for f in [:zeros, :ones]
     @eval Base.$f{T}(::Type{Tensor{T}}, args::Tuple) = constant($f(T, args))
 end
 
-function random_normal(shape; mean=0.0, stddev=1.0, name=nothing, kwargs...)
+@op function random_normal(shape; mean=0.0, stddev=1.0, name=nothing, kwargs...)
     local out
     with_op_name(name, "random_normal") do
         standard = Ops.random_standard_normal(shape; name=name, kwargs...)
@@ -29,6 +29,37 @@ function random_normal(shape; mean=0.0, stddev=1.0, name=nothing, kwargs...)
     end
     out
 end
+
+"""
+Outputs random values from a uniform distribution.
+The generated values follow a uniform distribution in the range `[minval, maxval)`.
+The lower bound `minval` is included in the range, while the upper bound `maxval` is excluded.
+In the integer case, the random integers are slightly biased unless
+`maxval - minval` is an exact power of two.
+The bias is small for values of `maxval - minval` significantly smaller than the
+range of the output (either 2**32 or 2**64).
+Args:
+* `shape`: A one dimensional `Tensor` or array containing the shape of the output `Tensor`.
+* `minval`: Lower bound on random values.
+* `maxval`: Upper bound on random values.
+* `seed`: An integer to seed the RNG with. Defaults to `0`, which results in random seed.
+* `dtype`: Optional datatype of random values generated. Default is `Float32`.
+Returns:
+A `Tensor` of the specified `shape` and `dtype` containing random values.
+"""
+@op function random_uniform(shape, minval, maxval; name=nothing, seed=0, dtype=Float32)
+    local out
+    with_op_name(name, "RandomUniformScaled") do
+        seed1 = 0
+        # TODO use global seed
+        seed2 = seed
+        r = random_uniform(shape; seed=seed1, seed2=seed2, dtype=dtype)
+        r
+        out = r .* (maxval-minval) + minval
+    end
+    out
+end
+
 
 @op function Base.shuffle(t::AbstractTensor; kwargs...)
     Ops.random_shuffle(t; kwargs...)

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -107,3 +107,12 @@ end
     run(sess, global_variables_initializer())
     run(sess, minimize_op)
 end
+
+@testset "dropout" begin
+    sess = Session(Graph())
+    inputs = constant(randn(Float32, 5, 32, 5))
+    drop_prob = placeholder(Float32)
+
+    dd =  nn.dropout(inputs, drop_prob)  # Check that this can actually be created
+
+end


### PR DESCRIPTION
>The new imported op has a different signature:
and does not support minval, maxval or dtype.
random_uniform(shape; seed=0, seed2=0)

This brings back old-functionality. So that `dropout` isn't broken anymore.

I'm not sure what is meant in the TODO about using global seed.
Does that mean something like 
`seed1=Base.Random.GLOBAL_RNG.seed |> first` ?


