### PR TITLE
Fix slice

### DIFF
--- a/src/ops/transformations.jl
+++ b/src/ops/transformations.jl
@@ -1,5 +1,4 @@
 import .Ops:
-    slice,
     strided_slice,
     expand_dims,
     tile,
@@ -401,5 +400,33 @@ end
 end
 
 Base.ctranspose(n::AbstractTensor) = transpose(n)
+
+
+"""
+slice(n::AbstractTensor, begin_, size_; name="")
+Extracts a slice from a tensor.
+This operation extracts a slice of size size from a tensor input starting at the location specified by begin. The slice size is represented as a tensor shape, where size[i] is the number of elements of the 'i'th dimension of input that you want to slice. The starting location (begin) for the slice is represented as an offset in each dimension of input. In other words, begin[i] is the offset into the 'i'th dimension of input that you want to slice from.
+begin is zero-based; size is one-based. If size[i] is -1, all remaining elements in dimension i are included in the slice. In other words, this is equivalent to setting:
+size[i] = input.dim_size(i) - begin[i]
+This operation requires that:
+0 <= begin[i] <= begin[i] + size[i] <= Di for i in [0, n]
+Args:
+input_: A Tensor.
+begin: An int32 or int64 Tensor.
+size: An int32 or int64 Tensor.
+name: A name for the operation (optional).
+Returns:
+A Tensor the same type as input.
+https://www.tensorflow.org/versions/r0.10/api_docs/python/array_ops.html#slice
+"""
+@op function slice(n::AbstractTensor, begin_, size_; name=nothing)
+    with_op_name(name, "Slice") do
+        begin_ = convert(Tensor{Int32}, begin_)
+        size_ = convert(Tensor{Int32}, size_)
+        Ops.slice(n, begin_, size_; name=name)
+    end
+end
+
+
 
 include("indexing.jl")

--- a/test/training.jl
+++ b/test/training.jl
@@ -1,0 +1,15 @@
+using Base.Test
+using TensorFlow
+
+
+@testset "slice" begin
+    let
+        sess = Session(Graph())
+        x = get_variable("x", (50,10), Float64)
+        x1 = TensorFlow.slice(x, [1,1],[-1,1])
+        cost = reduce_sum(x1)
+        optimizer = train.minimize(train.AdamOptimizer(), cost)
+        run(sess, global_variables_initializer())
+        @test size(run(sess, x1)) == (50, 1)
+    end
+end


### PR DESCRIPTION
Slice needs to have its arguments converted to `Int32`
It has been this way since:  https://github.com/malmaud/TensorFlow.jl/commit/b52651d8851e1450313d392ee3a2d8ed35a3cd5b
(cf #9)

I'm honestly not entirely sure why.

This PR adds a test and a fix.

The test fails with:

```julia
slice: Error During Test
  Got an exception of type RemoteException outside of a @test
  On worker 2:
  Python error: Tensor conversion requested dtype int32 for Tensor with dtype int64: 'Tensor("Slice/Sub
:0", shape=(2,), dtype=int64)'
   in py_gradients at /home/ubuntu/.julia/v0.5/TensorFlow/src/py.jl:46
   in #7 at /home/ubuntu/.julia/v0.5/TensorFlow/src/TensorFlow.jl:169
   in #645 at ./multi.jl:1421
   in run_work_thunk at ./multi.jl:1001
   in macro expansion at ./multi.jl:1421 [inlined]
   in #644 at ./event.jl:68
   in #remotecall_fetch#626(::Array{Any,1}, ::Function, ::Function, ::Base.Worker) at ./multi.jl:1070
   in remotecall_fetch(::Function, ::Base.Worker) at ./multi.jl:1062
   in #remotecall_fetch#629(::Array{Any,1}, ::Function, ::Function, ::Int64) at ./multi.jl:1080
   in remotecall_fetch(::Function, ::Int64) at ./multi.jl:1080
   in eval(::Module, ::Any) at ./boot.jl:234
   in gradients(::TensorFlow.Tensor{Float64}, ::Array{Any,1}, ::Void) at /home/ubuntu/.julia/v0.5/Tenso
rFlow/src/core.jl:1409
   in gradients(::TensorFlow.Tensor{Float64}, ::Array{Any,1}) at /home/ubuntu/.julia/v0.5/TensorFlow/sr
c/core.jl:1402
   in compute_gradients(::TensorFlow.train.AdamOptimizer, ::TensorFlow.Tensor{Float64}, ::Void) at /home/ubuntu/.julia/v0.5/TensorFlow/src/train.jl:48
   in #minimize#1(::Void, ::Void, ::Void, ::Function, ::TensorFlow.train.AdamOptimizer, ::TensorFlow.Tensor{Float64}) at /home/ubuntu/.julia/v0.5/TensorFlow/src/train.jl:40
   in macro expansion; at /mnt_volume/julia_dir/v0.5/TensorFlow/test/training.jl:22 [inlined]
   in macro expansion; at ./test.jl:674 [inlined]
   in anonymous at ./<missing>:?
   in include_from_node1(::String) at ./loading.jl:488
   in process_options(::Base.JLOptions) at ./client.jl:265
   in _start() at ./client.jl:321
Test Summary: | Error  Total
  slice       |     1      1
```

I built and tested this on top of several other changes (including #236).
In https://github.com/malmaud/TensorFlow.jl/tree/ox/fixslicefull
then cherry-picked this out into the PR.
Thus this might not pass until #236 is merged