### PR TITLE
add SVD binding re: #218

### DIFF
--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -30,6 +30,15 @@ import .Ops:
 @op Base.max(x::AbstractTensor, y; kwargs...) = Ops.maximum(x, y; kwargs...)
 @op Base.min(x::AbstractTensor, y; kwargs...) = Ops.minimum(x, y; kwargs...)
 
+
+@op function Base.svd(a::AbstractTensor; thin=true, kwargs...)
+    # Match Base names and ordering of results
+    s,u,v = Ops.svd(a; compute_uv=true, full_matrices=!thin, kwargs...)
+    u,s,v
+end
+
+
+
 const multiply = Ops.mul
 const negative = Ops.neg
 const self_adjoint_eig = Ops.self_adjoint_eig_v2


### PR DESCRIPTION
This wraps up the 

I am surprised at how poor the reconstruction error from the Tensorflow result is
I  found in one test 
 - the  julia error at 4.346551f-12
 - and the tensorflow error at 1.1636697f-10
Thus the factor of 100 in checking the error value.


Julia just [wraps LAPACK `gesdd!`]https://github.com/JuliaLang/julia/blob/bc606f6cc8bc6127979d90c6ccb239b2e2a14448/base/linalg/svd.jl#L28)

I am going to investigate further if there is actually a difference in accuracy of it it was just some bad luck for a particularly ill conditioned matrix in some sense.
But if I find anything wrong it is an upstream issue, anyway.

@alha02 
