### PR TITLE
Updates build.jl to use Official TF C Libs

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,10 +12,8 @@ if !isdir(bin_dir)
     run(`mkdir -p $bin_dir`)
 end
 
-# When TensorFlow 1.1 is released, use the official release binaries
-# of the TensorFlow C library. Do this by setting cur_version to 1.1.0
-# and then replacing the blocks below with:
-#=
+const cur_version = "1.1.0"
+
 function try_unzip()
     try
         run(`tar -xvzf $base/downloads/tensorflow.tar.gz --strip-components=2 ./lib/libtensorflow.so`)
@@ -28,73 +26,29 @@ function try_unzip()
     end
 end
 
+if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
+    info("Building TensorFlow.jl for use on the GPU")
+    processor = "gpu"
+else
+    info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
+    processor = "cpu"
+end
+
 @static if is_apple()
-    if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
-        info("Building TensorFlow.jl for use on the GPU")
-        url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-darwin-x86_64-$cur_version.tar.gz"
-    else
-        info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
-        url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-$cur_version.tar.gz"
-    end
-    open(joinpath(base, "downloads/tensorflow.tar.gz"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
-    mv("libtensorflow.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
+    ext = "dylib"
+    os = "darwin"
 end
 
 @static if is_linux()
-    if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
-        info("Building TensorFlow.jl for use on the GPU")
-        url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-$cur_version.tar.gz"
-    else
-        info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
-        url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-$cur_version.tar.gz"
-    end
-    r = Requests.get(url)
-    open(joinpath(base, "downloads/tensorflow.tar.gz"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
-    mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
-end
-=#
-
-function try_unzip()
-    try
-        run(`unzip -o $base/downloads/tensorflow.zip`)
-    catch err
-        if !isfile(joinpath(base, "libtensorflow_c.so"))
-            throw(err)
-        else
-            warn("Problem unzipping: $err")
-        end
-    end
+    ext = "so"
+    os = "linux"
 end
 
-const cur_version = "1.1.0"
+url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-$processor-$os-x86_64-$cur_version.tar.gz"
 
-@static if is_apple()
-    r = Requests.get("https://storage.googleapis.com/malmaud-stuff/tensorflow_mac_$cur_version.zip")
-    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
-    mv("libtensorflow.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
+r = Requests.get(url)
+open(joinpath(base, "downloads/tensorflow.tar.gz"), "w") do file
+    write(file, r.data)
 end
-
-@static if is_linux()
-    if "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
-        info("Building TensorFlow.jl for use on the GPU")
-        url = "https://storage.googleapis.com/malmaud-stuff/tensorflow_linux_$cur_version.zip"
-    else
-        info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
-        url = "https://storage.googleapis.com/malmaud-stuff/tensorflow_linux_cpu_$cur_version.zip"
-    end
-    r = Requests.get(url)
-    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
-    mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
-end
+try_unzip()
+mv("libtensorflow.so", "usr/bin/libtensorflow.$ext", remove_destination=true)


### PR DESCRIPTION
Credit to @asimshankar - I mostly just uncommented Asim's code.

Adds GPU support on MacOS
Updates NEWS and README
More info on lib download location: https://www.tensorflow.org/install/install_c

Only tested on macOS with both `ENV["TF_USE_GPU"] = "0"`, and `ENV["TF_USE_GPU"] = "1"` on julia 0.6-rc1 (n.b. ENV vars must be set in juliarc, ENV values in current REPL aren't used by Pkg.build - I guess it spawns a new julia process)