### PR TITLE
Reduce the number of dependancies

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Juno 0.2.3
 Compat 0.18
 MacroTools 0.3.6
 AutoHashEquals 0.1.0
+MNIST 0.0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.5
-Requests 0.3.10
 BinDeps 0.4.4
 ProtoBuf 0.3.0
 PyCall 1.7.1
@@ -7,8 +6,6 @@ Distributions 0.10.2
 Conda 0.2.3
 JLD 0.6.3
 FileIO 0.1.2
-MNIST 0.0.2
-Media 0.2.2
 Juno 0.2.3
 Compat 0.18
 MacroTools 0.3.6

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,7 @@
 julia 0.5
-BinDeps 0.4.4
 ProtoBuf 0.3.0
 PyCall 1.7.1
 Distributions 0.10.2
-Conda 0.2.3
 JLD 0.6.3
 FileIO 0.1.2
 Juno 0.2.3

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,3 @@
-import Requests
 
 base = dirname(@__FILE__)
 download_dir = joinpath(base, "downloads")
@@ -16,14 +15,18 @@ end
 # of the TensorFlow C library. Do this by setting cur_version to 1.1.0
 # and then replacing the blocks below with:
 #=
-function try_unzip()
+function download_and_unpack(url)
+    tensorflow_zip_path = joinpath(base, "downloads/tensorflow.zip")
+    # Download
+    download(url, tensorflow_zip_path)
+    # Unpack
     try
-        run(`tar -xvzf $base/downloads/tensorflow.tar.gz --strip-components=2 ./lib/libtensorflow.so`)
+        run(`tar -xvzf $(tensorflow_zip_path) --strip-components=2 ./lib/libtensorflow.so`)
     catch err
-        if !isfile(joinpath(base, "libtensorflow.so"))
+        if !isfile(joinpath(base, "libtensorflow_c.so"))
             throw(err)
         else
-            warn("Problem extracting $err")
+            warn("Problem unzipping: $err")
         end
     end
 end
@@ -36,10 +39,7 @@ end
         info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
         url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-$cur_version.tar.gz"
     end
-    open(joinpath(base, "downloads/tensorflow.tar.gz"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
+    download_and_unpack(url)
     mv("libtensorflow.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
 end
 
@@ -51,18 +51,21 @@ end
         info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
         url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-$cur_version.tar.gz"
     end
-    r = Requests.get(url)
-    open(joinpath(base, "downloads/tensorflow.tar.gz"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
+    download_and_unpack(url)
     mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
 end
 =#
 
-function try_unzip()
+const cur_version = "1.1.0"
+
+
+function download_and_unpack(url)
+    tensorflow_zip_path = joinpath(base, "downloads/tensorflow.zip")
+    # Download
+    download(url, tensorflow_zip_path)
+    # Unpack
     try
-        run(`unzip -o $base/downloads/tensorflow.zip`)
+        run(`unzip -o $(tensorflow_zip_path)`)
     catch err
         if !isfile(joinpath(base, "libtensorflow_c.so"))
             throw(err)
@@ -72,14 +75,9 @@ function try_unzip()
     end
 end
 
-const cur_version = "1.1.0"
 
 @static if is_apple()
-    r = Requests.get("https://storage.googleapis.com/malmaud-stuff/tensorflow_mac_$cur_version.zip")
-    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
+    download_and_unpack("https://storage.googleapis.com/malmaud-stuff/tensorflow_mac_$cur_version.zip")
     mv("libtensorflow.so", "usr/bin/libtensorflow.dylib", remove_destination=true)
 end
 
@@ -91,10 +89,6 @@ end
         info("Building TensorFlow.jl for CPU use only. To enable the GPU, set the TF_USE_GPU environment variable to 1 and rebuild TensorFlow.jl")
         url = "https://storage.googleapis.com/malmaud-stuff/tensorflow_linux_cpu_$cur_version.zip"
     end
-    r = Requests.get(url)
-    open(joinpath(base, "downloads/tensorflow.zip"), "w") do file
-        write(file, r.data)
-    end
-    try_unzip()
+    download_and_unpack(url)
     mv("libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
 end

--- a/deps/build_pytensorflow.jl
+++ b/deps/build_pytensorflow.jl
@@ -1,5 +1,3 @@
-using Requests
-
 if is_apple()
     conda_url = "https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
 elseif is_unix()


### PR DESCRIPTION
The number of dependencies we have is huge. (see https://juliaobserver.com/packages/TensorFlow for upstream)
This cuts it down a little.
Biggest change being to get rid of Requests.jl, and just use `Base.download` in the build.jl.
This should knock out maybe 5 or more further upstream requirements.

This also gets rid of a couple of other requirements, that are not used at all.

Other packages maybe that could be shed:
 -  Juno.jl
     - only used for a small amount of improved `show`
     - this would also get rid of the indirect Hiccup.jl and Media.jl, requirement
     - I think we should keep this; hopefully optional packages will come in soon (lots of discussion going around there)
 - Distributions.jl
    - This would knock out about 8 upstream dependencies
    - I don't think we do much with it that couldn't be done with `Base.rand` and `Base.randn` 
    - Probably worth its own PR, if it is worth doing