### PR TITLE
Added documentation for building from source (with or without GPU support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,6 @@ $ pip install --upgrade tensorflow
 
 ## Optional: Using a custom TensorFlow binary
 
-If you already have a version of `libtensorflow.so` or `libtensorflow.dylib` that you would like to use, you can set the environment variable `LIBTENSORFLOW` to its path. By default, TensorFlow.jl will use the library in `TensorFlow.jl/deps/usr/bin`.
+To build TensorFlow from source, or if you already have a TensorFlow binary that you wish to use, follow the instructions at https://malmaud.github.io/tfdocs/build_from_source/. This is recommended by Google for maximum performance, and is currently needed for Mac OS X GPU support.
 
-If you want to build your own version of the TensorFlow binary library instead of relying on the one that is installed with
-`Pkg.build("TensorFlow")`, follow the instructions from https://www.tensorflow.org/install/install_sources, except:
-
-* In the section "Build the pip package", instead run `bazel build --config=opt //tensorflow:libtensorflow.so`.
-* Then copy the file "bazel-bin/tensorflow/libtensorflow.so" to the "deps/usr/bin" directory in the TensorFlow.jl package.
-* On OS X, rename the file to `libtensorflow.dylib`.
-
-A convenience script is included to use Docker to easily build the library. Just install docker and run `julia build_libtensorflow.so` from the "deps" directory of the TensorFlow.jl package.
+For Linux users, a convenience script is included to use Docker to easily build the library. Just install docker and run `julia build_libtensorflow.so` from the "deps" directory of the TensorFlow.jl package. Note that this method may not link to all libraries available on the target system such as Intel MKL.

--- a/docs/src/build_from_source.md
+++ b/docs/src/build_from_source.md
@@ -1,0 +1,48 @@
+# Building TensorFlow from source
+
+Building TensorFlow from source is recommended by Google for maximum performance - on some systems, the difference can be substantial. It will also be required for Mac OS X GPU support for versions later than 1.1. This document describes how to do so.
+
+
+## Step 1: build libtensorflow
+
+To build libtensorflow for TensorFlow.jl, follow the steps here: https://www.tensorflow.org/install/install_sources, except for a few minor modifications.
+
+  * Ignore the step "Install python dependencies".
+  * In the step "Build the pip package", since we are building the binary file and not the pip package, instead run `bazel build --config=opt //tensorflow:libtensorflow.so`, adding `--config=cuda` if GPU support is desired.
+
+Running `bazel build` will produce the `libtensorflow.so` binary needed by TensorFlow.jl - there is no need to build the Python package or run anything else. You may place the binary wherever is convenient.
+
+
+## Step 2: add necessary environment variables
+
+To use a custom TensorFlow binary, we must set the appropriate environment variables so that TensorFlow.jl knows its location, and if GPU support is desired, so that CUDA is loaded correctly.
+For users using the Atom/Juno IDE, this may be done by adding the following two lines to the `init.coffee` script (easily accessible by clicking `File -> Init Script`).
+
+  * `process.env.LD_LIBRARY_PATH = "/usr/local/cuda/lib:..."`
+  * `process.env.LIBTENSORFLOW = "/path/to/libtensorflow.so"`
+
+
+## Step 3: check that the custom binary is loaded
+
+After running `using TensorFlow`, it should no longer complain that TensorFlow wasn't compiled with the necessary instructions. Try generating two random matrices and multiplying them together. You can time the computation with `@time run(sess, x)`, which should be much faster.
+
+
+## Tips & known issues
+
+  * If you encounter segmentation faults or other errors, try `Pkg.checkout("TensorFlow")`.
+
+  * For maximum performance, you should always compile on the same system that will be running the computation, and with the correct CUDA Compute Capability version supported by your GPU.
+
+  * If you get `CUDA_ERROR_NOT_INITIALIZED`, then for some reason TensorFlow cannot find your GPU. Make sure that the appropriate software is installed, and if using an external GPU, make sure it is plugged in correctly.
+
+  * To check whether GPU is being used, create your session with `TensorFlow.Session(config=TensorFlow.tensorflow.ConfigProto(log_device_placement=true))`. TensorFlow will then print information about which device is used.
+
+  * Currently, TensorFlow.jl uses Python interop for `tf.gradients`, because it is not implemented in the TensorFlow C API.  If you encounter issues, you may need to update the `tensorflow` package in Conda.jl by running `Conda.update("tensorflow")`.
+
+  * You may need to add symlinks from `libcudnn5.dylib` to `libcudnn.5.dylib` so that Bazel is able to correctly locate the necessary dependencies.
+
+  * On Mac OS X, `nvcc`, Nvidia's CUDA compiler, requires OS X Command Line Tools version 7.3 and does not work with the latest version. You can download this version from Apple's website, and switch to it by running `sudo xcode-select -s /path/to/CommandLineTools`.
+
+  * On Mac OS X, make sure to set the environment variable `GCC_HOST_COMPILER_PATH` to `/usr/bin/gcc` - do not install GCC yourself, or the build may fail with obscure error messages.
+
+  * On Mac OS X, if you don't wish to install Homebrew, you can instead use Julia's internal Homebrew-based dependency manager Homebrew.jl by running ```Homebrew.brew(`install --build-from-source libtensorflow`)```. GPU support can be enabled by modifying the Ruby formula using ```Homebrew.brew(`edit libtensorflow`)``` -- you should set all necessary environment variables in the Ruby formula, as Homebrew may not display prompts correctly.

--- a/docs/src/build_from_source.md
+++ b/docs/src/build_from_source.md
@@ -7,19 +7,22 @@ Building TensorFlow from source is recommended by Google for maximum performance
 
 To build libtensorflow for TensorFlow.jl, follow the steps here: https://www.tensorflow.org/install/install_sources, except for a few minor modifications.
 
-  * Ignore the step "Install python dependencies".
+  * In the step "Prepare environment", ignore "Install python dependencies" -- these are not necessary as we are not building for Python. Be sure to follow all other steps as needed for your OS.
   * In the step "Build the pip package", since we are building the binary file and not the pip package, instead run `bazel build --config=opt //tensorflow:libtensorflow.so`, adding `--config=cuda` if GPU support is desired.
 
 Running `bazel build` will produce the `libtensorflow.so` binary needed by TensorFlow.jl - there is no need to build the Python package or run anything else. You may place the binary wherever is convenient.
 
 
-## Step 2: add necessary environment variables
+## Step 2: install TensorFlow binary
 
-To use a custom TensorFlow binary, we must set the appropriate environment variables so that TensorFlow.jl knows its location, and if GPU support is desired, so that CUDA is loaded correctly.
-For users using the Atom/Juno IDE, this may be done by adding the following two lines to the `init.coffee` script (easily accessible by clicking `File -> Init Script`).
+We must now tell TensorFlow.jl to load the custom binary. There are a number of ways to do so.
 
-  * `process.env.LD_LIBRARY_PATH = "/usr/local/cuda/lib:..."`
-  * `process.env.LIBTENSORFLOW = "/path/to/libtensorflow.so"`
+  * The simplest way is to copy `libtensorflow.so` to `~/.julia/v0.?/TensorFlow/deps/usr/bin/`, overwriting the included binary. If on Mac OS X, you may need to rename the file to `libtensorflow.dylib`.
+
+  * Alternatively, for users who wish to keep their `libtensorflow.so` file elsewhere, or those who do not wish to modify their `TensorFlow.jl` installation, we can set the environment variable `LIBTENSORFLOW` to `/path/to/tensorflow.so`. This may be done system-wide by editing `.profile` or any other method supported by your OS.
+
+  * For users of the Atom/Juno IDE who do not wish to modify their system-wide environment, environment variables may be set by adding the line `process.env.LIBTENSORFLOW = "/path/to/libtensorflow.so"` to the `init.coffee` script (easily accessible by clicking `File -> Init Script`). Note that Atom may not always inherit environment variables set by the OS.
+
 
 
 ## Step 3: check that the custom binary is loaded
@@ -33,11 +36,11 @@ After running `using TensorFlow`, it should no longer complain that TensorFlow w
 
   * For maximum performance, you should always compile on the same system that will be running the computation, and with the correct CUDA Compute Capability version supported by your GPU.
 
+  * If TensorFlow.jl fails to load with the error `Library not loaded: @rpath/libcublas.8.0.dylib` or any similar error, it means that the CUDA libraries are not in `LD_LIBRARY_PATH` as required by Nvidia. Be sure to add `/usr/local/cuda/lib`, or wherever your CUDA instalation is located, to `LD_LIBRARY_PATH`. This may be done by editing `.profile`, or for Atom/Juno users editing `init.coffee`, or any other method supported by your OS, as described in Step 2. Be careful that you append this folder and do not mistakenly overwrite your entire path.
+
   * If you get `CUDA_ERROR_NOT_INITIALIZED`, then for some reason TensorFlow cannot find your GPU. Make sure that the appropriate software is installed, and if using an external GPU, make sure it is plugged in correctly.
 
   * To check whether GPU is being used, create your session with `TensorFlow.Session(config=TensorFlow.tensorflow.ConfigProto(log_device_placement=true))`. TensorFlow will then print information about which device is used.
-
-  * Currently, TensorFlow.jl uses Python interop for `tf.gradients`, because it is not implemented in the TensorFlow C API.  If you encounter issues, you may need to update the `tensorflow` package in Conda.jl by running `Conda.update("tensorflow")`.
 
   * You may need to add symlinks from `libcudnn5.dylib` to `libcudnn.5.dylib` so that Bazel is able to correctly locate the necessary dependencies.
 

--- a/docs/src/build_from_source.md
+++ b/docs/src/build_from_source.md
@@ -32,6 +32,8 @@ After running `using TensorFlow`, it should no longer complain that TensorFlow w
 
 ## Tips & known issues
 
+  * Dynamic RNNs currently do not work due to an upstream bug in TensorFlow. See: https://github.com/malmaud/TensorFlow.jl/issues/203 and https://github.com/tensorflow/tensorflow/issues/8669.
+
   * If you encounter segmentation faults or other errors, try `Pkg.checkout("TensorFlow")`.
 
   * For maximum performance, you should always compile on the same system that will be running the computation, and with the correct CUDA Compute Capability version supported by your GPU.

--- a/docs/src/build_from_source.md
+++ b/docs/src/build_from_source.md
@@ -46,7 +46,7 @@ After running `using TensorFlow`, it should no longer complain that TensorFlow w
 
   * You may need to add symlinks from `libcudnn5.dylib` to `libcudnn.5.dylib` so that Bazel is able to correctly locate the necessary dependencies.
 
-  * On Mac OS X, `nvcc`, Nvidia's CUDA compiler, requires OS X Command Line Tools version 7.3 and does not work with the latest version. You can download this version from Apple's website, and switch to it by running `sudo xcode-select -s /path/to/CommandLineTools`.
+  * On Mac OS X, `nvcc`, Nvidia's CUDA compiler, requires OS X Command Line Tools version 8.2 and does not work with the latest version. You can download this version from Apple's website, and switch to it by running `sudo xcode-select -s /path/to/CommandLineTools`.
 
   * On Mac OS X, make sure to set the environment variable `GCC_HOST_COMPILER_PATH` to `/usr/bin/gcc` - do not install GCC yourself, or the build may fail with obscure error messages.
 


### PR DESCRIPTION
After the discussion in Issue #220, I figured it'd make sense to write a documentation page on building from source. Currently, the information needed for everything to work is scattered in between TensorFlow documentation pages and various issues on this repo.

It would be great to add some information about the binary patch in #245 so that users may incorporate it. That way potential segfaults and unexpected behavior are avoided.