### PR TITLE
use_gpu is not const

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,7 +7,7 @@ const cur_version = "1.1.0"
 # Determine if using GPU
 ############################
 
-const use_gpu = "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
+use_gpu = "TF_USE_GPU" ∈ keys(ENV) && ENV["TF_USE_GPU"] == "1"
 
 if is_apple() && use_gpu
     warn("No support on OS X, for GPU use. Falling back to CPU")


### PR DESCRIPTION
Trivial change.
I mistakenly had `use_gpu` as a `const` variable.
But it is modified, if you are on Mac, and say you want to use the GPU.
It will work fine, but give a warning.