### PR TITLE
[Failing] Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ docs/build
 
 *.swp
 *.jld
+
+deps/c_api\.h
+
+deps/LICENSE

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -56,14 +56,8 @@ end
 base = dirname(@__FILE__)
 download_dir = joinpath(base, "downloads")
 bin_dir = joinpath(base, "usr/bin")
-
-if !isdir(download_dir)
-    mkdir(download_dir)
-end
-
-if !isdir(bin_dir)
-    run(`mkdir -p $bin_dir`)
-end
+mkpath(download_dir)
+mkpath(bin_dir)
 
 
 function download_and_unpack(url)

--- a/test/control.jl
+++ b/test/control.jl
@@ -1,5 +1,5 @@
 using Base.Test
-
+using TensorFlow
 sess = Session(Graph())
 
 first = TensorFlow.constant(collect(1:16))

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,4 +1,5 @@
 using Base.Test
+using TensorFlow
 
 sess = TensorFlow.Session(TensorFlow.Graph())
 

--- a/test/proto.jl
+++ b/test/proto.jl
@@ -1,5 +1,5 @@
 # Test loading/saving of protos
-
+using Base.Test
 using TensorFlow: load_proto
 
 let

--- a/test/windows_attempt_runtests.jl
+++ b/test/windows_attempt_runtests.jl
@@ -1,0 +1,25 @@
+# This is a temporary testing file, for purposes of debugging what is going on with windows
+
+julia = Cmd([joinpath(JULIA_HOME, "julia.exe")])
+
+tests = [
+    "math.jl",
+    "meta.jl",
+    "control.jl",
+    "nn.jl",
+    "training.jl",
+]
+
+for test in tests
+    println(test)
+
+    try
+        run(`$julia $test`)
+    catch err
+        warn(err)
+    end
+
+    println("")
+    println("-------------")
+    println("")
+end


### PR DESCRIPTION
I wanted to see exactly how far we are from having windows support. (#204)

This is roughly what it looks like.
the PR  includes a build script,
which downloads the libtensorflow from google.
(This means that until https://github.com/tensorflow/tensorflow/issues/8669 is solved upstream we won't have dynamic RNNs, because they rely on @malmaud's custom patch.)

One particular problem is that it requires Python 3.5.
Which AFAICT one can only get our of Conda.jl by doing a re `Pkg.build` of it with the environment variables `CONDA_JL_VERSION` set to 3 (rather than the default 2).

The majority of tests pass.

The tests which fail are the ones from:    "math.jl",   "meta.jl",     "control.jl",     "nn.jl", and    "training.jl".
And they don't so much fail, as segfault.


One minimal example is:
```julia
julia> TensorFlow.group(placeholder(Int32))
2017-08-18 16:27:20.004158: F .\tensorflow/core/lib/gtl/inlined_vector.h:157] Check failed: i < size() (0 vs. 0)
```

All the errors are of that form: `<timestamp>: F <path the a header file> Check failed: <assertions>`.


**NB** While this is labelled WIP, it is not actually in progress.
I don't have any immediate plans to finish this off and make windows work.

