### PR TITLE
Make statsfuns compatible #298

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,7 @@ ProtoBuf 0.3.0
 PyCall 1.7.1
 Conda 0.6.0
 Distributions 0.10.2
+StatsFuns 0.3.0
 JLD 0.6.3
 FileIO 0.1.2
 Juno 0.2.3

--- a/src/ops/nn.jl
+++ b/src/ops/nn.jl
@@ -3,7 +3,7 @@ module nn
 using Compat
 import TensorFlow
 const tf = TensorFlow
-import .tf: Ops, @op, @not_implemented, @tf
+import .tf: Ops, @op, @not_implemented, @tf, AbstractTensor
 
 import .Ops:
     relu,
@@ -21,6 +21,12 @@ import .Ops:
     log_softmax,
     dilation2d,
     conv2d
+
+import StatsFuns
+@tf.op StatsFuns.log1pexp(x::AbstractTensor; kwargs...) = Ops.softplus(x; kwargs...)
+@tf.op StatsFuns.softmax(x::AbstractTensor; kwargs...) = Ops.softmax(x; kwargs...)
+@tf.op StatsFuns.logistic(x::AbstractTensor; kwargs...) = Ops.sigmoid(x; kwargs...)
+
 
 include("rnn_cell.jl")
 import .rnn_cell:  zero_state, output_size, state_size

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -1,6 +1,6 @@
 using TensorFlow
 using Base.Test
-
+using StatsFuns
 
 @testset "conv2d_transpose" begin
     let
@@ -13,7 +13,7 @@ using Base.Test
                           filter=>randn(Float32, 3, 3, 5, 3),
                           shape_=>[32,10,10,5]))
     end
-end
+end|
 
 
 @testset "Cross Entropy Loss" begin
@@ -192,4 +192,20 @@ end
     topk_values, topk_indices = run(sess, nn.top_k(inputs,2))
     @test topk_values == [10,7]
     @test topk_indices == [2,4]
+end
+
+@testset "Activation Functions" begin
+    sess = Session(Graph())
+    run_op(op, val)=run(sess, op(constant(val)))
+
+    x = 0.5
+    xs = [-0.5, 0.0, 0.5, 0.6]'
+
+    @test logistic(x) == run_op(logistic, x) == run_op(nn.sigmoid, x)
+    @test logistic.(xs) == run_op(logistic, xs) == run_op(nn.sigmoid, xs)
+
+    @test StatsFuns.softmax(xs) == run_op(nn.softmax, xs)
+
+    @test softplus(x) == run_op(log1pexp, x) == run_op(nn.softplus, x)
+    @test softplus.(xs) == run_op(log1pexp, xs) == run_op(nn.softplus, xs)
 end

--- a/test/nn.jl
+++ b/test/nn.jl
@@ -13,7 +13,7 @@ using StatsFuns
                           filter=>randn(Float32, 3, 3, 5, 3),
                           shape_=>[32,10,10,5]))
     end
-end|
+end
 
 
 @testset "Cross Entropy Loss" begin
@@ -151,8 +151,6 @@ for (rnn_fun, post_proc_outputs) in ((nn.dynamic_rnn, identity), (nn.rnn, last))
             @test size(state_jl) == (19, 7) #batchsize, hidden_size
         end
     end
-
-
 end
 
 @testset "rnn gradients" begin
@@ -204,7 +202,7 @@ end
     @test logistic(x) == run_op(logistic, x) == run_op(nn.sigmoid, x)
     @test logistic.(xs) == run_op(logistic, xs) == run_op(nn.sigmoid, xs)
 
-    @test StatsFuns.softmax(xs) == run_op(nn.softmax, xs)
+    @test softmax(xs) == run_op(nn.softmax, xs)
 
     @test softplus(x) == run_op(log1pexp, x) == run_op(nn.softplus, x)
     @test softplus.(xs) == run_op(log1pexp, xs) == run_op(nn.softplus, xs)


### PR DESCRIPTION
Close #298

Possible issue with softmax.

Tensorflow operates per row on matrix.
StatsFuns operates on the whole matrix

```julia

julia> run(Session(), nn.softmax(x))
4×4 Array{Float64,2}:
 0.182344  0.176948  0.312947  0.327761
 0.34033   0.152795  0.170746  0.336128
 0.284187  0.273225  0.219796  0.222792
 0.177648  0.349585  0.238929  0.233839

julia> softmax(x)
4×4 Array{Float64,2}:
 0.0428782  0.0416093  0.0735896  0.077073 
 0.0928664  0.0416934  0.0465917  0.0917197
 0.0774796  0.0744908  0.0599243  0.0607409
 0.0389658  0.0766791  0.0524073  0.0512909
```