### PR TITLE
[WIP] Handle difficulties relating to while_loop

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -448,6 +448,10 @@ struct TFException <: Exception
     status::Status
 end
 
+function Base.show(io::IO, err::TFException)
+    print(io, "TFException($err.status): Status Code: $(get_code(err.status))")
+end
+
 function check_status(status)
     if get_code(status) ≠ TF_OK
         throw(TFException(status))
@@ -1017,6 +1021,15 @@ function with_op_name(f, name, def_name="Node")
     end
 end
 
+
+"""
+     with_op_control(f, control_ops)
+
+Any ops declared inside `f` will not execute until after all op listed in `control_ops`.
+This enforces order of execution.
+It is useful if the op in `f` may depend on the execution of one or more of the `control_ops` first.
+see also [Python Docs](https://www.tensorflow.org/versions/r0.12/api_docs/python/framework/core_graph_data_structures#Graph.control_dependencies)
+"""
 function with_op_control(f, control_ops)
     g = get_def_graph()
     push!(g.op_context.control_ops, control_ops)

--- a/test/breaklibtensorflow.jl
+++ b/test/breaklibtensorflow.jl
@@ -1,0 +1,33 @@
+using TensorFlow
+import TensorFlow: get_tensors, with_op_name, with_frame
+
+sess = Session(Graph())
+i = constant(1; name="ff")
+
+
+variables = [i]
+
+
+g = Graph()
+def_graph = get_def_graph()
+g.op_context = def_graph.op_context
+g.name_idx = def_graph.name_idx
+g.collections = def_graph.collections
+
+as_default(g) do
+    with_frame(2, true, false) do
+        context = get_def_graph().op_context.while_context[end]
+        enter_op = Ops.enter(i, frame_name=context.context_name)
+    end
+end
+
+####################
+
+
+
+sess=Session(Graph())
+j=constant(31)
+g=Graph()
+c=as_default(g) do
+    c = 2*j
+end

--- a/test/minimal_breaking_example.jl
+++ b/test/minimal_breaking_example.jl
@@ -1,0 +1,12 @@
+
+using TensorFlow
+
+sess = Session(Graph())
+i = constant(1, name="a")
+try
+    end_i = TensorFlow.while_loop((i->i <= 10), i->i+1, [i])
+
+    run(sess, end_i)
+catch err
+    @show err
+end


### PR DESCRIPTION
I'm not longer certain that https://github.com/tensorflow/tensorflow/issues/8669 is actually an upstream issue.
At least not in the form we see it most often -- the while_loop


My MWE is:

```julia
using TensorFlow

sess = Session(Graph())
i = constant(1)
end_i = TensorFlow.while_loop((i->i <= 10), i->i+1, [i])
```

Giving: 
```
Tensorflow error: Status: Input 0 ('Const') for 'while/Enter' was not previously added to ShapeRefiner.
```

But actually this can be reproduced more simply via:
```julia
sess=Session(Graph())
j=constant(31)
g=Graph()
c_o=as_default(g) do
    c = 2*j
end
```

giving: 
```
Tensorflow error: Status: Input 1 ('Const') for 'Mul' was not previously added to ShapeRefiner.
```

Because that is basically what is happening.
We are creating a new graph, 
and then referring to nodes in the old-graph in it.

The reason we can get away with supressing the errors via the [custom patch](https://github.com/malmaud/TensorFlow.jl/blob/master/deps/build_libtensorflow/gpu/upstream_patch)
is because we then go and  transfer stuff back to the original graph such that by run-time all the references we made are in fact valid.

I'm not sure how exactly to fix this.
It'll need more thought.

This PR currently contains my refactoring of the code as I dug in and tried to understand it.
