### PR TITLE
Make identity overload Base.identity

### DIFF
--- a/src/ops/control_flow.jl
+++ b/src/ops/control_flow.jl
@@ -1,6 +1,13 @@
 using Compat
 
-import .Ops: identity, no_op, count_up_to
+import .Ops: no_op, count_up_to
+
+"""
+     `identity(input)`
+
+Return a tensor with the same shape and contents as the input tensor or value.
+"""
+@op Base.identity(tensor::AbstractTensor; name=nothing) = Ops.identity(tensor; name=name)
 
 @op function make_tuple(tensors; name="", control_inputs=Operation[])
     group_deps = group(vcat(tensors, control_inputs)...)

--- a/test/control.jl
+++ b/test/control.jl
@@ -1,22 +1,27 @@
 using Base.Test
+using TensorFlow
 
-sess = Session(Graph())
 
-first = TensorFlow.constant(collect(1:16))
-second = run(sess, TensorFlow.identity(first))
-@test collect(1:16) == second
-third = run(sess, TensorFlow.make_tuple([TensorFlow.constant(collect(1:16)), TensorFlow.constant(collect(1:16))]))
-@test [collect(1:16), collect(1:16)] == third
+@testset "identity and make_tuple" begin
+    sess = Session(Graph())
+    first = constant(collect(1:16))
+    second = run(sess, identity(first))
+    @test collect(1:16) == second
+    third = run(sess, TensorFlow.make_tuple([constant(collect(1:16)), constant(collect(1:16))]))
+    @test [collect(1:16), collect(1:16)] == third
+end
 
-x = TensorFlow.constant(2)
-y = TensorFlow.constant(5)
-f1 = ()->17x
-f2 = ()->y+23
-result = run(sess, Base.cond(x<y, f1, f2))
-@test 17*2 == result
-inc = constant(1)
-i = constant(1)
-w = while_loop((i,s)->i≤5, (i,s)->[i+inc, s+i], [i, 0])
-@test run(sess, w)[2] == sum(1:5)
-grad = gradients(w[1], i)
-@test run(sess, grad) == 1
+@testset "cond and while_loop" begin
+    x = constant(2)
+    y = constant(5)
+    f1 = ()->17x
+    f2 = ()->y+23
+    result = run(sess, cond(x<y, f1, f2))
+    @test 17*2 == result
+    inc = constant(1)
+    i = constant(1)
+    w = TensorFlow.while_loop((i,s)->i≤5, (i,s)->[i+inc, s+i], [i, 0])
+    @test run(sess, w)[2] == sum(1:5)
+    grad = gradients(w[1], i)
+    @test run(sess, grad) == 1
+end

--- a/test/init_ops.jl
+++ b/test/init_ops.jl
@@ -1,17 +1,15 @@
 using TensorFlow
 using Base.Test
 
+
 sess = Session(Graph())
 
 c = ConstantInitializer(2.0)
 @test rand(c, 2, 3) == fill(2.0, 2, 3)
 
-let
-    initializer = zeros_initializer()
-    @test run(sess, initializer([2,3])) == zeros(2,3)
-end
 
-let
-    initializer = ones_initializer(Float64)
-    @test run(sess, initializer([2,3])) == ones(2, 3)
-end
+initializer = zeros_initializer()
+@test run(sess, initializer([2,3])) == zeros(2,3)
+
+initializer = ones_initializer(Float64)
+@test run(sess, initializer([2,3])) == ones(2, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ tests = [
 "debug.jl",
 "hello.jl",
 "image.jl",
-"init_ops.jl"
+"init_ops.jl",
 "io.jl",
 "math.jl",
 "meta.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ tests = [
 "run.jl",
 "sequences.jl",
 "shape_inference.jl",
-"show.jl"
+"show.jl",
 "summary.jl",
 "train.jl",
 "training.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,27 +8,28 @@ include(joinpath(dirname(@__FILE__), "..", "examples", "logistic.jl"))
 # Main tests
 
 tests = [
-    "hello.jl",
-    "core.jl",
-    "shape_inference.jl",
-    "math.jl",
-    "debug.jl",
-    "comp.jl",
-    "clipping.jl",
-    "image.jl",
-    "transformations.jl",
-    "proto.jl",
-    "meta.jl",
-    "control.jl",
-    "ops.jl",
-    "summary.jl",
-    "nn.jl",
-    "sequences.jl",
-    "run.jl",
-    "training.jl",
-    "train.jl",
-    "io.jl",
-    "show.jl"
+"clipping.jl",
+"comp.jl",
+"control.jl",
+"core.jl",
+"debug.jl",
+"hello.jl",
+"image.jl",
+"init_ops.jl"
+"io.jl",
+"math.jl",
+"meta.jl",
+"nn.jl",
+"ops.jl",
+"proto.jl",
+"run.jl",
+"sequences.jl",
+"shape_inference.jl",
+"show.jl"
+"summary.jl",
+"train.jl",
+"training.jl",
+"transformations.jl",
 ]
 
 # @test_nowarn was added in Julia 0.6.


### PR DESCRIPTION
I'm pretty sure this used to be the case.
It was useful because adding an identity node can be used to easily give an pseudo-operation a name in the graph.
Eg the output of `gradients` is not intrinsically named.


Also while I was at it I cleaned up a few tests.
Perhaps most interestingly I spotted that `test/init_ops.jl` was not being run by `runtests`



