### PR TITLE
Make String tensors scalar like

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -122,6 +122,9 @@ end
 
 cast_type(T, val) = val
 
+tf_shape(x::Union{Number,String}) = TensorShape(Int[])
+tf_shape(x::AbstractArray)        = TensorShape(collect(size(x)))
+
 """
     check_shape(tensor, value)
 
@@ -129,7 +132,7 @@ Throws an error if the size of the value is not a possile shape for the tensor
 """
 function check_shape(tensor, value)
     tensor_shape = get_shape(tensor)
-    value_shape = TensorShape(collect(size(value)))
+    value_shape = tf_shape(value)
 
     try
         unified_shape = ShapeInference.unify(tensor_shape, value_shape)

--- a/src/shape_inference.jl
+++ b/src/shape_inference.jl
@@ -131,8 +131,7 @@ register_shape("Placeholder") do op
 end
 
 register_shape("Const") do op
-    value = get(load_const(op))
-    [TensorShape([size(value)...])]
+    [TensorShape([x.size for x in get_def(op).attr["value"].tensor.tensor_shape.dim])]
 end
 
 # Simple 1-input 1-output functions that preserve the input shape

--- a/test/shape_inference.jl
+++ b/test/shape_inference.jl
@@ -229,3 +229,8 @@ end
 	@test Z_shapes[1] == Z_shapes[2] == Z_shapes[3]
     end
 end
+
+@testset "get_shape (of known dimensions) should match computed size. x is $x" for x in (1, fill(1, 1), fill(1, 1, 1), "Julia")
+    t = constant(x)
+    @test get_shape(t) == TensorShape(run(Session(), size(t)))
+end


### PR DESCRIPTION
Was trying out the [image recognition tutorial](https://www.tensorflow.org/tutorials/image_recognition) a had some issues with the string tensor. I'm new to TensorFlow but I think these changes are necessary to get the right behavior for string tensors. At least it was necessary for the tutorial code to work and I think the intermediate results are similar to the Python version. Do you handle string tensor in a special way in this package?