### PR TITLE
squaring of global_norm adaptive to data type

### DIFF
--- a/src/ops/clipping.jl
+++ b/src/ops/clipping.jl
@@ -50,7 +50,7 @@ end
     local out
     tensor_value(t) = Tensor(t)
     tensor_value(t::IndexedSlices) = t.values
-    square(t) = muliply(t, t)
+    square(t) = multiply(t, t)
     with_op_name(name, "GlobalNorm") do
         out = sqrt(add_n([reduce_sum(square(tensor_value(t))) for t in t_list]))
     end

--- a/src/ops/clipping.jl
+++ b/src/ops/clipping.jl
@@ -50,7 +50,7 @@ end
     local out
     tensor_value(t) = Tensor(t)
     tensor_value(t::IndexedSlices) = t.values
-    square(t) = t .^ convert(Tensor{eltype(t)}, 2.0)
+    square(t) = t .* t
     with_op_name(name, "GlobalNorm") do
         out = sqrt(add_n([reduce_sum(square(tensor_value(t))) for t in t_list]))
     end

--- a/src/ops/clipping.jl
+++ b/src/ops/clipping.jl
@@ -50,7 +50,7 @@ end
     local out
     tensor_value(t) = Tensor(t)
     tensor_value(t::IndexedSlices) = t.values
-    square(t) = t .* t
+    square(t) = muliply(t, t)
     with_op_name(name, "GlobalNorm") do
         out = sqrt(add_n([reduce_sum(square(tensor_value(t))) for t in t_list]))
     end

--- a/src/ops/clipping.jl
+++ b/src/ops/clipping.jl
@@ -50,8 +50,9 @@ end
     local out
     tensor_value(t) = Tensor(t)
     tensor_value(t::IndexedSlices) = t.values
+    square(t) = t .^ convert(Tensor{eltype(t)}, 2.0)
     with_op_name(name, "GlobalNorm") do
-        out = sqrt(add_n([reduce_sum(tensor_value(t).^2.0) for t in t_list]))
+        out = sqrt(add_n([reduce_sum(square(tensor_value(t))) for t in t_list]))
     end
     out
 end


### PR DESCRIPTION
I noticed there is a `.^2.0` which would always produce `Float64`. Not sure if this is the best way to deal with it but let me know otherwise. 