### PR TITLE
saver.max_to_keep needs to sort versions before discarding old versions

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -239,6 +239,7 @@ function FileIO.save(saver::Saver, session::Session, path; global_step=nothing)
     end
     if length(versions) > saver.max_to_keep
         to_delete = length(versions) - saver.max_to_keep
+        sort!(versions)
         for i in 1:to_delete
             rm(joinpath(dirname(path), "$base_path-$(versions[i])"), force=true)
         end

--- a/test/train.jl
+++ b/test/train.jl
@@ -1,7 +1,7 @@
 using TensorFlow
 using Base.Test
 
-@testset "train.save and train.resore" begin
+@testset "save and resore" begin
     try
         let
             session = Session(Graph())
@@ -24,7 +24,7 @@ using Base.Test
 end
 
 
-@testset "train.save and train.resore global_step" begin
+@testset "save and restore max_to_keep" begin
     try
         let
             session = Session(Graph())

--- a/test/train.jl
+++ b/test/train.jl
@@ -24,6 +24,38 @@ using Base.Test
 end
 
 
+@testset "train.save and train.resore global_step" begin
+    try
+        let
+            session = Session(Graph())
+            x = get_variable("x", [], Float32)
+            run(session, assign(x, 5.f0))
+            saver = train.Saver(max_to_keep=5)
+            for i in 1:12
+                train.save(saver, session, "weights.jld", global_step=i)
+            end
+        end
+
+        let
+            session = Session(Graph())
+            @tf x = get_variable([], Float32)
+            saver = train.Saver()
+            for i in 1:7
+                @test_throws SystemError train.restore(saver, session, "weights.jld-$i")
+            end
+            for i in 8:12
+                train.restore(saver, session, "weights.jld-$i")
+                @test run(session, x) == 5.0f0
+            end
+        end
+    finally
+        for i in 1:12
+            rm("weights.jld-$i"; force=true)
+        end
+    end
+end
+
+
 @testset "metagraph importing and exporting" begin
     mktempdir() do tmppath
         modelfile = joinpath(tmppath, "my_model")


### PR DESCRIPTION
I think this PR follows the original intent of the function and that `sort!` call was accidentally omitted.

Example of what this commit changes. Let's say we're saving checkpoints named

```
1
2
3
4
5
6
7
8
9
10
11
```

With `max_to_keep=5` we would expect only 7,8,9,10,11 to remain. But 10 and 11 are lexicographically sorted before 2 so (at least on OS X) `readdir` gives the following list:

```
1
10
11
2
3
4
5
6
7
8
9
```

And we'll only keep: 5, 6, 7, 8, 9 and we'll discard the last checkpoints that was saved most recently.

The solution is to not rely on the order from `readdir` and call `sort!` on the versioned checkpoints.