### PR TITLE
named Variable with @tf

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -77,6 +77,9 @@ function Variable(initial_value; name="", trainable=true, literal_name=false)
     return self
 end
 
+"""Variable is not an @op, but it supports the name argument"""
+tf.withname(::Type{Variable}, name) = tf.withname(tf.RegisteredOp(), Variable, name)
+
 @tf.with_def_graph function Variable(graph::tf.Graph, s::AbstractString)
     var_node = tf.Tensor(get(tf.get_node_by_name(graph, s)))
     assign_node = tf.Tensor(get(tf.get_node_by_name(graph, "$s/Assign")))

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -18,7 +18,7 @@ end
 @testset "Naming" begin
     let
         g = Graph()
-        local i, j_jl, j, k, ijk, ij, ij2, fq, m, W, Y, Ysum1, Ysum2, Ysum3, Ysum4
+        local i, j_jl, j, k, ijk, ij, ij2, fq, m, W, Y, Ysum1, Ysum2, Ysum3, Ysum4, Z
         as_default(g) do
             @tf begin
                 i = constant(1.0)
@@ -46,6 +46,8 @@ end
                 Ysum3 = reduce_sum(Y, keep_dims=true) # With a comma (issue #188)
 
                 Ysum4 = reduce_sum(Y, keep_dims=true, name="namefor_Ysum4") # With a comma (issue #188)
+
+                Z = Variable([1,2,3])
             end
         end
 
@@ -69,7 +71,7 @@ end
         @test Ysum3 == get_tensor_by_name(g, "Ysum3")
         @test Ysum4 == get_tensor_by_name(g, "namefor_Ysum4")
 
-
+        @test Tensor(Z.var_node) == get_tensor_by_name(g, "Z")
     end
 end
 


### PR DESCRIPTION
I expect to be able to name a Variable with `@tf` just like I can name operations.

This makes
```
@tf W = Variable(data)
```
effectively translate to
```
W = Variable(data; name="W")
```