### PR TITLE
Use Hiccup.span

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ Compat 0.18
 MacroTools 0.3.6
 AutoHashEquals 0.1.0
 MNIST 0.0.2
+Hiccup 0.1.0

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,5 +1,6 @@
 using Juno
 using PyCall
+import Hiccup
 import Juno: Tree, Row, fade, interleave
 
 @render Juno.Inline t::Tensor begin
@@ -7,7 +8,7 @@ import Juno: Tree, Row, fade, interleave
   shape = s.rank_unknown ? [fade("unknown")] :
     interleave(map(dim -> get(dim, fade("?")), s.dims), fade("×"))
   Tree(Row(fade(try string(eltype(t)," ") catch e "" end),
-           Juno.span(".constant.support.type", "Tensor "),
+           Hiccup.span(".constant.support.type", "Tensor "),
            shape...),
        [Text("name: $(node_name(t.op))"),
         Text("index: $(t.value_index)")])


### PR DESCRIPTION
Juno.span referred to Hiccup.span. But Hiccup is no longer used by Juno since https://github.com/JunoLab/Juno.jl/commit/5f3bd718c051adeaf8944a0782f55470b7788024.

I don't know how to add a unit test for this functionality since the results is supposed to be rendered in Juno.