### PR TITLE
Remove extra sigmoid from GRU

### DIFF
--- a/src/ops/rnn_cell.jl
+++ b/src/ops/rnn_cell.jl
@@ -218,7 +218,7 @@ function (cell::GRUCell)(input, state, input_dim=-1)
         z = sigmoid(X*Wz + Bz)
         r = sigmoid(X*Wr + Br)
         X2 = [input state.*r]
-        h = nn.tanh(sigmoid(X2*Wh + Bh))
+        h = nn.tanh(X2*Wh + Bh)
         s2 = (1-z).*h + z.*state
     end
     return [s2, s2]


### PR DESCRIPTION
It was just wrong AFAICT
Sigmoid inside a tanh is basically the same as replacing the tanh with a sigmoid.
So it may actually have had meaningful effect.
Though I don't think so, I believe from the GRU design that that variable (which I think of as potential new state), really can have any choice of activation functions.
Unlike the gates which are constrained by the design.

Still the traditional activation function is `tanh`  there.