### PR TITLE
Fix haskey

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1529,11 +1529,11 @@ Throws a `NodeNameNotFound` exception if there is no such tensor.
     return Tensor(node, port)
 end
 
-#Indexing based name Access
+# Indexing based name Access
 Base.getindex(graph::Graph, name) = get_tensor_by_name(graph, name)
 Base.values(graph::Graph) = get_operations(graph)
 Base.keys(graph::Graph) = (node_name(op) for op in values(graph))
-Base.haskey(graph::Graph, name) = isnull(get_node_by_name(graph, name))
+Base.haskey(graph::Graph, name) = !isnull(get_node_by_name(graph, name))
 
 
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -78,6 +78,9 @@ end
     sess= Session(g)
     x = placeholder(Float64, name="x")
     @test g["x"] == x
+    @test haskey(g,"x")
+    @test !haskey(g,"y")
+    @test collect(keys(g)) == ["x"]
 end
 @testset "Disconnected gradients" begin
     let


### PR DESCRIPTION
Turn's out `haskey(graph, node_name)` was always wrong but no one noticed.
This fixes it and adds tests