### PR TITLE
Add ability to import names that are already used in Base

### DIFF
--- a/src/generate_ops.jl
+++ b/src/generate_ops.jl
@@ -328,11 +328,13 @@ Returns a reference to a Julia function corresponding to the operation.
 function import_op(name)
     jl_name = opname_to_jlname(name)
     mod = TensorFlow.Ops
-    if !isdefined(mod, jl_name)
+    if jl_name ∉ names(mod, true)
         ops = Dict(get_all_op_list())
         op = ops[name]
         op_desc = to_function(op)
         eval(Ops, op_desc.expr)
+    else
+        warn("Import Skipped: tried to import op $name as $(mod).$(jl_name), but that already exists.")
     end
 
     return getfield(Ops, jl_name)

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -8,3 +8,11 @@ using Base.Test
     as_string = import_op("AsString")
     @test run(session, as_string(2)) == "2"
 end
+
+
+
+import_op("Atan2") #Must be outside testset as per https://github.com/JuliaLang/julia/issues/27244
+@testset "Importing a name that is used by Base" begin
+    session = Session(Graph())
+    @test run(session, Ops.atan2(Tensor(1.0), Tensor(1.0))) > 0 
+end


### PR DESCRIPTION
I wanted to be able to do 

`import_op("Atan2")` and have that work as `Ops.atan2`.
This makes that possible.

Only change really was to make it use `names` to check, rather than `isdefined`.

Hard part was getting the tests to work because https://github.com/JuliaLang/julia/issues/27244
