### PR TITLE
conda-forge doesn't have tensorflow=1.7.0, but it does have 1.8.0

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,9 +39,8 @@ end
 
 if PyCall.conda
     Conda.add_channel("conda-forge")
-    Conda.add("tensorflow=" * cur_py_version)
     Conda.add("tensorboard=" * cur_py_version)
-    Conda.add("numpy") # unclear why this is needed
+    Conda.add("tensorflow=" * cur_py_version)
 else
     try
         pyimport("tensorflow")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,9 +39,9 @@ end
 
 if PyCall.conda
     Conda.add_channel("conda-forge")
-    Conda.add("numpy") # missing dependency of the conda tensorflow package
     Conda.add("tensorflow=" * cur_py_version)
     Conda.add("tensorboard=" * cur_py_version)
+    Conda.add("numpy") # unclear why this is needed
 else
     try
         pyimport("tensorflow")
@@ -107,4 +107,3 @@ end
     mv("$lib_dir/libtensorflow.so", "usr/bin/libtensorflow.so", remove_destination=true)
     mv("$lib_dir/libtensorflow_framework.so", "usr/bin/libtensorflow_framework.so", remove_destination=true)
 end
-

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,8 +1,8 @@
 using PyCall
 using Conda
 
-const cur_version = "1.7.0"
-const cur_py_version = "1.7.0"
+const cur_version = "1.8.0"
+const cur_py_version = "1.8.0"
 
 
 
@@ -39,6 +39,7 @@ end
 
 if PyCall.conda
     Conda.add_channel("conda-forge")
+    Conda.add("numpy") # missing dependency of the conda tensorflow package
     Conda.add("tensorflow=" * cur_py_version)
     Conda.add("tensorboard=" * cur_py_version)
 else


### PR DESCRIPTION
Getting the following error message during `Pkg.build("TensorFlow")` on `v0.9.0`
```
Warning: 'conda-forge' already in 'channels' list, moving to the top
Solving environment: failed

PackagesNotFoundError: The following packages are not available from current channels:

  - tensorflow=1.7.0
```

I can't find 1.7.0 on [anaconda.org/conda-forge](https://anaconda.org/conda-forge/tensorflow/files) either. But it does have `tensorflow=1.8.0`.

However the 1.8.0 package doesn't seem to install `numpy` as it should. I'm getting this message:
```
julia> pyimport("tensorflow")
...
pyimport sais ImportError('No module named numpy',)
...
```
Installing numpy explicitly seems to do the trick.