### PR TITLE
Expand tilde when looking for LIBTENSORFLOW

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -18,7 +18,7 @@ macro tfcall(sym, ret, args, vals...)
             "LIBTENSORFLOW",
             joinpath(LIB_BASE, "usr", "bin", "libtensorflow"))
         if LIBTF_PTR[] == C_NULL
-            LIBTF_PTR[] = Libdl.dlopen(tf_path)
+            LIBTF_PTR[] = Libdl.dlopen(expanduser(tf_path))
         end
         func = Libdl.dlsym(LIBTF_PTR[], $sym)
         ccall(func, $(esc(ret)), $(esc(args)), $(esc.(vals)...))


### PR DESCRIPTION
Fixes comment from https://github.com/malmaud/TensorFlow.jl/issues/400#issuecomment-395952667

@colbec 
>My mistake was in thinking that Julia would be able to evaluate the tilde for the home directory.
Replacing the tilde with the full "/home/..." resolved that issue.
But the comment about AVX2 and FMA remains. I'm looking into it.


idk, if this is the right thing to do or not.
On the one-hand: I see no downsides, on the other-hand I'm aware a lot of programs do not do this. So maybe there is a reason?


This does not currently have tests. We could make tests only awkwardly.
We'ld need to move the file and start a new julia session.
(I think we might start a new julia session for some tests? I feel like I've done it before.)

c.f.: https://github.com/JuliaLang/julia/issues/24152
 --> https://github.com/JuliaLang/julia/issues/1136