### PR TITLE
Add a versionoinfo function that dumps out all the info needed for debugging

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
-If making bug report please copy and paste in to the issue the output of 
+If you are making a bug report, please copy and paste the output of the following Julia snippit into the issue:
+
 ```
 using TensorFlow
 tf_versioninfo()

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+If making bug report please copy and paste in to the issue the output of 
+```
+using TensorFlow
+tf_versioninfo()
+```

--- a/src/TensorFlow.jl
+++ b/src/TensorFlow.jl
@@ -124,7 +124,8 @@ get_all_op_list,
 Ops,
 slice,
 import_op,
-@tfimport
+@tfimport,
+tf_versioninfo
 
 const pyproc = Ref(0)
 
@@ -176,6 +177,7 @@ macro py_proc(expr)
     end
 end
 
+include("version.jl")
 include("meta.jl")
 include("constants.jl")
 include("tensorflow_protos.jl")

--- a/src/TensorFlow.jl
+++ b/src/TensorFlow.jl
@@ -177,12 +177,13 @@ macro py_proc(expr)
     end
 end
 
-include("version.jl")
+
 include("meta.jl")
 include("constants.jl")
 include("tensorflow_protos.jl")
 include("core.jl")
 include("run.jl")
+include("version.jl")
 include("ops.jl")
 
 include("variable.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -44,64 +44,6 @@ macro required(keywords...)
     end
 end
 
-"""
-    tf_version(kind=:backend)
-
-Return the version number of the tensorflow library.
-
-If `kind` is `:backend`, return the version of the TensorFlow binary loaded
-into the Julia process.
-
-If `kind` is `:julia`, return the version of the Julia TensorFlow package.
-
-If `kind` is `:python`, return the version of the Python API.
-"""
-function tf_version(; kind=:backend)
-    if kind == :backend
-        res = @tfcall(:TF_Version, Cstring, ()) |> unsafe_string
-    elseif kind == :python
-        res = fetch(@py_proc py_tf[][:VERSION])
-    elseif kind == :julia
-        return Pkg.installed("TensorFlow")
-    else
-        error("Kind '$kind' not recognized")
-    end
-    # Deal with version strings like "0.12.head"
-    res = replace(res, r"\.head$", "")
-    VersionNumber(res)
-end
-
-function version_check(v)
-    if tf_version() < v
-        error("You have TensorFlow binary version $(tf_version()), but need version $v to use this functionality. Please upgrade with `Pkg.build(\"TensorFlow\").")
-    end
-end
-
-"""
-    py_version_check(;print_warning=true)
-
-Returns true if the Python TensorFlow version is comptabile with the TensorFlow binary used by the
-Julia process.
-
-If `print_warning` is true, print a warning with upgrade instructions if the versions are
-incompatible.
-"""
-function py_version_check(;print_warning=true, force_warning=false)
-    py_version = tf_version(kind=:python)
-    lib_version = tf_version(kind=:backend)
-    if (py_version < lib_version) || force_warning
-        base_msg = "Your Python TensorFlow client version ($py_version) is below the TensorFlow backend version ($lib_version). This can cause various errors. Please upgrade your Python TensorFlow installation and then restart Julia."
-        if PyCall.conda
-            upgrade_msg = "You can upgrade by calling `using Conda; Conda.update();` from Julia."
-        else
-            upgrade_msg = "Typically, executing `pip install --upgrade tensorflow` from the command line will upgrade Python TensorFlow. You may need admninistrator privileges."
-        end
-        full_msg = "$(base_msg)\n$(upgrade_msg)"
-        print_warning && warn(full_msg)
-        return false
-    end
-    return true
-end
 
 mutable struct Status
     ptr::Ptr{Void}

--- a/src/version.jl
+++ b/src/version.jl
@@ -1,0 +1,109 @@
+"""
+    tf_version(kind=:backend)
+
+Return the version number of the tensorflow library.
+
+If `kind` is `:backend`, return the version of the TensorFlow binary loaded
+into the Julia process.
+
+If `kind` is `:julia`, return the version of the Julia TensorFlow package.
+
+If `kind` is `:python`, return the version of the Python API.
+"""
+function tf_version(; kind=:backend)
+    if kind == :backend
+        res = @tfcall(:TF_Version, Cstring, ()) |> unsafe_string
+    elseif kind == :python
+        res = fetch(@py_proc py_tf[][:VERSION])
+    elseif kind == :julia
+        return Pkg.installed("TensorFlow")
+    else
+        error("Kind '$kind' not recognized")
+    end
+    # Deal with version strings like "0.12.head"
+    res = replace(res, r"\.head$", "")
+    VersionNumber(res)
+end
+
+function version_check(v)
+    if tf_version() < v
+        error("You have TensorFlow binary version $(tf_version()), but need version $v to use this functionality. Please upgrade with `Pkg.build(\"TensorFlow\").")
+    end
+end
+
+"""
+    py_version_check(;print_warning=true)
+
+Returns true if the Python TensorFlow version is compatible with the TensorFlow binary used by the
+Julia process.
+
+If `print_warning` is true, print a warning with upgrade instructions if the versions are
+incompatible.
+"""
+function py_version_check(;print_warning=true, force_warning=false)
+    py_version = tf_version(kind=:python)
+    lib_version = tf_version(kind=:backend)
+    if (py_version < lib_version) || force_warning
+        base_msg = "Your Python TensorFlow client version ($py_version) is below the TensorFlow backend version ($lib_version). This can cause various errors. Please upgrade your Python TensorFlow installation and then restart Julia."
+        if PyCall.conda
+            upgrade_msg = "You can upgrade by calling `using Conda; Conda.update();` from Julia."
+        else
+            upgrade_msg = "Typically, executing `pip install --upgrade tensorflow` from the command line will upgrade Python TensorFlow. You may need administrator privileges."
+        end
+        full_msg = "$(base_msg)\n$(upgrade_msg)"
+        print_warning && warn(full_msg)
+        return false
+    end
+    return true
+end
+
+macro tryshow(ex)
+	quote
+		try
+			@show $(esc(ex))
+		catch err
+			println("Trying to evaluate ",
+					$(Meta.quot(ex)),
+					" but got error: ",
+					err
+					)
+		end
+		nothing
+	end
+end
+
+function tf_versioninfo()
+	println("Please copy-paste all this info into any bug reports.")
+	println("Note that this may display some errors. But not all errors are bad. Some are expected")
+	
+	println()
+	println("----------------")
+	println("Library Versions")
+	println("----------------")
+	@tryshow tf_version(kind=:backend) 
+	@tryshow tf_version(kind=:python)
+	@tryshow tf_version(kind=:julia)
+	
+	println()
+	println("---------------------")
+	println("Environment Variables")
+	println("---------------------")
+	
+	@tryshow ENV["TF_USE_GPU"]
+	@tryshow ENV["LIBTENSORFLOW"]
+	
+	println()
+	println("-------------")
+	println("Python Status")
+	println("-------------")
+	@tryshow PyCall.conda
+	@tryshow PyCall.PYTHONHOME
+	@tryshow readstring(`pip --version`)
+	@tryshow readstring(`pip3 --version`)
+	
+	println()
+	println("------------")
+	println("Julia Status")
+	println("------------")
+	versioninfo()
+end

--- a/src/version.jl
+++ b/src/version.jl
@@ -73,8 +73,8 @@ macro tryshow(ex)
 end
 
 function tf_versioninfo()
-    println("Please copy-paste all this info into any bug reports.")
-    println("Note that this may display some errors. But not all errors are bad. Some are expected")
+    println("Wording: Please copy-paste the entirely of the below output into any bug reports.")
+    println("Note that this may display some errors, depending upon on your configuration. This is fine.")
     
     println()
     println("----------------")

--- a/src/version.jl
+++ b/src/version.jl
@@ -58,52 +58,49 @@ function py_version_check(;print_warning=true, force_warning=false)
 end
 
 macro tryshow(ex)
-	quote
-		try
-			@show $(esc(ex))
-		catch err
-			println("Trying to evaluate ",
-					$(Meta.quot(ex)),
-					" but got error: ",
-					err
-					)
-		end
-		nothing
-	end
+    quote
+        try
+            @show $(esc(ex))
+        catch err
+            println("Trying to evaluate ",
+                    $(Meta.quot(ex)),
+                    " but got error: ",
+                    err
+                    )
+        end
+        nothing
+    end
 end
 
 function tf_versioninfo()
-	println("Please copy-paste all this info into any bug reports.")
-	println("Note that this may display some errors. But not all errors are bad. Some are expected")
-	
-	println()
-	println("----------------")
-	println("Library Versions")
-	println("----------------")
-	@tryshow tf_version(kind=:backend) 
-	@tryshow tf_version(kind=:python)
-	@tryshow tf_version(kind=:julia)
-	
-	println()
-	println("---------------------")
-	println("Environment Variables")
-	println("---------------------")
-	
-	@tryshow ENV["TF_USE_GPU"]
-	@tryshow ENV["LIBTENSORFLOW"]
-	
-	println()
-	println("-------------")
-	println("Python Status")
-	println("-------------")
-	@tryshow PyCall.conda
-	@tryshow PyCall.PYTHONHOME
-	@tryshow readstring(`pip --version`)
-	@tryshow readstring(`pip3 --version`)
-	
-	println()
-	println("------------")
-	println("Julia Status")
-	println("------------")
-	versioninfo()
+    println("Please copy-paste all this info into any bug reports.")
+    println("Note that this may display some errors. But not all errors are bad. Some are expected")
+    
+    println()
+    println("----------------")
+    println("Library Versions")
+    println("----------------")
+    @tryshow ENV["TF_USE_GPU"]
+    @tryshow ENV["LIBTENSORFLOW"]
+    println()
+    @tryshow tf_version(kind=:backend) 
+    @tryshow tf_version(kind=:python)
+    @tryshow tf_version(kind=:julia)  
+    
+    
+    println()
+    println("-------------")
+    println("Python Status")
+    println("-------------")
+    @tryshow PyCall.conda
+	@tryshow ENV["PYTHON"]
+    @tryshow PyCall.PYTHONHOME
+    @tryshow readstring(`pip --version`)
+    @tryshow readstring(`pip3 --version`)
+    
+    println()
+    println("------------")
+    println("Julia Status")
+    println("------------")
+    versioninfo()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ if !isdefined(Base.Test, Symbol("@test_nowarn"))
 end
 
 
-tf_versioninfo()
+tf_versioninfo() # Dump out all the info at start of the test, for easy debugging from logs. (also check `tf_versioninfo()` itself works)
 
 for filename in tests
     name = first(splitext(filename))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,9 @@ if !isdefined(Base.Test, Symbol("@test_nowarn"))
     end
 end
 
+
+tf_versioninfo()
+
 for filename in tests
     name = first(splitext(filename))
     @testset "$name" begin


### PR DESCRIPTION
This is to help with making it easier to process issues.

Basically the user can run `tf_versioninfo()` and it outputs basically all the info that might possibly be relevant.
Some of the info will be irrelevant, like checking the `pip --version` if it was installed with Conda.
But I figured it is easier just ignore the irrelevant parts.
Alternatively, it could be made slightly more complex and avoid including things that probably don't matter.
But it is kind of hard to tell what interesting setups people might be using.


Example output:

```
julia> tf_versioninfo()
Please copy-paste all this info into any bug reports.
Note that this may display some errors. But not all errors are bad. Some are expected

----------------
Library Versions
----------------
tf_version(kind=:backend) = v"1.7.0"
tf_version(kind=:python) = v"1.7.0"
tf_version(kind=:julia) = v"0.9.0"

---------------------
Environment Variables
---------------------
Trying to evalute ENV["TF_USE_GPU"] but got error: KeyError("TF_USE_GPU")
Trying to evalute ENV["LIBTENSORFLOW"] but got error: KeyError("LIBTENSORFLOW
")

-------------
Python Status
-------------
PyCall.conda = true
PyCall.PYTHONHOME = "/home/wheel/oxinabox/.julia/v0.6/Conda/deps/usr:/home/wheel/oxinabox/.julia/v0.6/Conda/deps/usr"
readstring(@cmd("pip --version")) = "pip 10.0.1 from /usr/local/lib/python3.5/dist-packages/pip (python 3.5)\n"
readstring(@cmd("pip3 --version")) = "pip 10.0.1 from /usr/local/lib/python3.5/dist-packages/pip (python 3.5)\n"

-------------
Julia Status
-------------
Julia Version 0.6.3
Commit d55cadc350 (2018-05-28 20:20 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Xeon(R) CPU           E5520  @ 2.27GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Nehalem)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, nehalem)
```