### PR TITLE
Make the autoname inserting a function of the argument types

### DIFF
--- a/src/meta.jl
+++ b/src/meta.jl
@@ -160,8 +160,10 @@ macro tf(ex)
         # If they are found replace them with `withname` wrapped calls
         # and then search with in them
         MacroTools.prewalk(ex) do x
-            if @capture(x, X_ = f_(args__))
-                :($X = TensorFlow.withname($f, $(string(X)),$(args...)))
+            if @capture(x, X_ = f_(args__; kwargs__)) # semicolon breaks it
+                :($X = TensorFlow.withname($f, $(string(X)), $(args...); $(kwargs...)))
+            elseif @capture(x, X_ = f_(args__))
+                :($X = TensorFlow.withname($f, $(string(X)), $(args...)))
             else
                 x
             end

--- a/src/ops/indexing.jl
+++ b/src/ops/indexing.jl
@@ -32,7 +32,9 @@ end
 Base.first(tr::TensorRange)=tr.start
 Base.last(tr::TensorRange)=tr.stop
 
-@define_binary Base.:(:) TensorRange
+Base.:(:)(start::AbstractTensor, stop::AbstractTensor) =  TensorRange(start, stop)
+Base.:(:)(start, stop::AbstractTensor) =  TensorRange(start, stop)
+Base.:(:)(start::AbstractTensor, stop) =  TensorRange(start, stop)
 
 
 const Slice = Union{TensorRange, UnitRange, Colon}

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -9,12 +9,42 @@ using TensorFlow
     @test TensorFlow.is_registered_op(typeof(add_n)) == TensorFlow.RegisteredOp()
     @test TensorFlow.is_registered_op(typeof(nn.softmax)) == TensorFlow.RegisteredOp()
 
-    @test_throws MethodError TensorFlow.is_registered_op(add_n)
-    @test_throws MethodError TensorFlow.is_registered_op(nn.softmax)
+
+    @tesetset "args matter" begin
+        @test TensorFlow.is_registered_op(typeof(placeholder), Int) == TensorFlow.RegisteredOp()
+        @test TensorFlow.is_registered_op(typeof(placeholder)) == TensorFlow.NotRegisteredOp()
+    end
+end
+
+@testset "Types with typeparams" begin
+    @tf begin
+        fooo = nn.rnn_cell.DropoutWrapper(nn.rnn_cell.GRUCell(3), Tensor(0.2))
+        @test true # Above line would have errored if @tf macro was broken
+    end
+end
+
+@testset "colon #448" begin
+    @tf for ii in 1:10
+    end
+    @test true # would have errored if this was broken
+end
+
+@testset "While" begin
+    @test_broken let
+        sess = Session(Graph())
+        i = constant(1)
+        loop_sum = constant(0)
+        res = @tf while i ≤ 10
+            sq = i.^2
+            [i=>i+1, loop_sum=>loop_sum+sq]
+        end
+        @test run(sess, res) == [11, 385]
+    end
 end
 
 
-@testset "Naming" begin
+
+@testset "Naming Big Demo" begin
     let
         g = Graph()
         local i, j_jl, j, k, ijk, ij, ij2, fq, m, W, Y, Ysum1, Ysum2, Ysum3, Ysum4
@@ -70,22 +100,4 @@ end
     end
 end
 
-@testset "Types with typeparams" begin
-    @tf begin
-        fooo = nn.rnn_cell.DropoutWrapper(nn.rnn_cell.GRUCell(3), Tensor(0.2))
-            @test true # Above line would have errored if @tf macro was broken
-    end
-end
 
-@testset "While" begin
-    @test_broken let
-        sess = Session(Graph())
-        i = constant(1)
-        loop_sum = constant(0)
-        res = @tf while i ≤ 10
-            sq = i.^2
-            [i=>i+1, loop_sum=>loop_sum+sq]
-        end
-        @test run(sess, res) == [11, 385]
-    end
-end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -3,16 +3,34 @@ using TensorFlow
 
 @testset "Registering Ops" begin
 
-    @test TensorFlow.is_registered_op(TensorFlow.FIFOQueue) == TensorFlow.RegisteredOp()
-    @test TensorFlow.is_registered_op(nn.rnn_cell.GRUCell) == TensorFlow.NotRegisteredOp()
+    @testset "Registered types" begin
+        # Only the 2 arg version should be registered
+        @test TensorFlow.is_registered_op(TensorFlow.FIFOQueue, 32, [Int,Float32]) == TensorFlow.RegisteredOp()
+        @test TensorFlow.is_registered_op(TensorFlow.FIFOQueue, 32) == TensorFlow.NotRegisteredOp()
+        @test TensorFlow.is_registered_op(TensorFlow.FIFOQueue) == TensorFlow.NotRegisteredOp()
+    end
 
-    @test TensorFlow.is_registered_op(typeof(add_n)) == TensorFlow.RegisteredOp()
-    @test TensorFlow.is_registered_op(typeof(nn.softmax)) == TensorFlow.RegisteredOp()
+    @testset "Unregistered types" begin
+        @test TensorFlow.is_registered_op(nn.rnn_cell.GRUCell) == TensorFlow.NotRegisteredOp()
+        @test TensorFlow.is_registered_op(nn.rnn_cell.GRUCell, 32) == TensorFlow.NotRegisteredOp()
+    end
+
+    @testset "Registered Functions" begin
+        @test TensorFlow.is_registered_op(typeof(nn.softmax), [1,0]) == TensorFlow.RegisteredOp()
+        @test TensorFlow.is_registered_op(typeof(nn.softmax)) == TensorFlow.NotRegisteredOp()
+        @test TensorFlow.is_registered_op(typeof(nn.softmax), [1,0], 2) == TensorFlow.NotRegisteredOp()
 
 
-    @tesetset "args matter" begin
         @test TensorFlow.is_registered_op(typeof(placeholder), Int) == TensorFlow.RegisteredOp()
         @test TensorFlow.is_registered_op(typeof(placeholder)) == TensorFlow.NotRegisteredOp()
+
+        @test TensorFlow.is_registered_op(typeof(placeholder), Int) == TensorFlow.RegisteredOp()
+        @test TensorFlow.is_registered_op(typeof(placeholder)) == TensorFlow.NotRegisteredOp()
+    end
+
+    @testset "Unregistered Functions" begin
+        @test TensorFlow.is_registered_op(typeof(string)) == TensorFlow.NotRegisteredOp()
+        @test TensorFlow.is_registered_op(typeof(string),3 ) == TensorFlow.NotRegisteredOp()
     end
 end
 


### PR DESCRIPTION
This is needed,
as different methods (with different argument types) may or may not support the name kwarg,
and we only want to insert it for ones that do.

Conveniently since the traits are built on dispatch already it is only a small change,

Closes #448 
Those  it turns out that the problem in #448, re the use of `:`
actually is unrelated to the main thrust of this PR:
 `TensorRange` doesn't take a `name` kwarg,
and so the `:` overloads shouldn't actually have been declared with `@op` at all.
But a different bug actually prevented that being visible in 0.6,
