### PR TITLE
Add equality overrides for `Device` and `DevicePart`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -72,11 +72,14 @@ end
 device_index_from_zero(part::DevicePart{Int}) = "$(join(part.kind, ":")):$(part.index-1)"
 device_index_from_zero(part::DevicePart) = "$(join(part.kind, ":")):$(part.index)"
 
+==(a::DevicePart, b::DevicePart) = a.kind == b.kind && a.index == b.index
+
 struct Device
     parts::Vector{DevicePart}
 end
 
 Device() = Device(DevicePart[])
+==(a::Device, b::Device) = a.parts == b.parts
 
 function DevicePart(s::AbstractString)
     parts = split(s, ":")

--- a/src/core.jl
+++ b/src/core.jl
@@ -64,7 +64,7 @@ function get_code(s::Status)
     return TF_Code(code)
 end
 
-struct DevicePart{IndexType}
+@auto_hash_equals struct DevicePart{IndexType}
     kind::Vector{String}
     index::IndexType
 end
@@ -72,14 +72,11 @@ end
 device_index_from_zero(part::DevicePart{Int}) = "$(join(part.kind, ":")):$(part.index-1)"
 device_index_from_zero(part::DevicePart) = "$(join(part.kind, ":")):$(part.index)"
 
-==(a::DevicePart, b::DevicePart) = a.kind == b.kind && a.index == b.index
-
-struct Device
+@auto_hash_equals struct Device
     parts::Vector{DevicePart}
 end
 
 Device() = Device(DevicePart[])
-==(a::Device, b::Device) = a.parts == b.parts
 
 function DevicePart(s::AbstractString)
     parts = split(s, ":")


### PR DESCRIPTION
This is needed for our XLA work, so that we can ensure that the device a
tensor is coming fron matches the device a model is running on.