### PR TITLE
Make unary "-" work with @tf

### DIFF
--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -167,7 +167,9 @@ function Base.round(::Type{T}, value::AbstractTensor) where T
 end
 
 
--(n::AbstractTensor; kwargs...) = negative(n; kwargs...)
+function -(n::AbstractTensor; kwargs...)
+    negative(n; kwargs...)
+end
 
 @op function Base.complex(x_r::AbstractTensor, x_i::AbstractTensor; kwargs...)
     Ops.complex(x_r, x_i; kwargs...)

--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -167,7 +167,7 @@ function Base.round(::Type{T}, value::AbstractTensor) where T
 end
 
 
-function -(n::AbstractTensor; kwargs...)
+@op function -(n::AbstractTensor; kwargs...)
     negative(n; kwargs...)
 end
 

--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -167,7 +167,7 @@ function Base.round(::Type{T}, value::AbstractTensor) where T
 end
 
 
--(n::AbstractTensor) = negative(n)
+-(n::AbstractTensor; kwargs...) = negative(n; kwargs...)
 
 @op function Base.complex(x_r::AbstractTensor, x_i::AbstractTensor; kwargs...)
     Ops.complex(x_r, x_i; kwargs...)

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -60,7 +60,11 @@ end
     end
 end
 
-
+@testset "Negating and @tf" begin
+    a = tf.constant(1)    
+    @tf b = -a
+    @test true # Above line would have errored if unary - didn't work with @tf
+end
 
 @testset "Naming Big Demo" begin
     let

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -61,7 +61,7 @@ end
 end
 
 @testset "Negating and @tf" begin
-    a = tf.constant(1)    
+    a = constant(1)    
     @tf b = -a
     @test true # Above line would have errored if unary - didn't work with @tf
 end


### PR DESCRIPTION
As is, it errors because of the `name` keyword when used with `@tf`.