### PR TITLE
avoid displaying cmd objects in tf_version_info

### DIFF
--- a/src/version.jl
+++ b/src/version.jl
@@ -60,16 +60,19 @@ function py_version_check(;print_warning=true, force_warning=false)
     return true
 end
 
-macro tryshow(ex)
+macro tryshow(ex, msg="")
+    if msg==""
+        msg = Meta.quot(ex)
+    end
     quote
         try
-            println($(Meta.quot(ex)),
+            println($(msg),
                     " = ",
                     $(esc(ex))
                     )
         catch err
             println("Trying to evaluate ",
-                    $(Meta.quot(ex)),
+                    $(msg),
                     " but got error: ",
                     err
                     )
@@ -101,8 +104,8 @@ function tf_versioninfo()
     @tryshow PyCall.conda
 	@tryshow ENV["PYTHON"]
     @tryshow PyCall.PYTHONHOME
-    @tryshow String(read(`pip --version`))
-    @tryshow String(read(`pip3 --version`))
+    @tryshow String(read(`pip --version`)) "pip --version"
+    @tryshow String(read(`pip3 --version`)) "pip3 --version"
 
     println()
     println("------------")


### PR DESCRIPTION
Before 

```
-------------
Python Status
-------------
PyCall.conda = true
Trying to evaluate ENV["PYTHON"] but got error: KeyError("PYTHON")
PyCall.PYTHONHOME = /Users/oxinabox/.julia/conda/3:/Users/oxinabox/.julia/conda/3
String(read(#= /Users/oxinabox/Documents/talks/JuliaDeepLearningMeetupLondon2019/dev/Te
nsorFlow/src/version.jl:105 =# (Core.:(@cmd))("pip --version"))) = pip 18.1 from /usr/l
ocal/lib/python2.7/site-packages/pip (python 2.7)

String(read(#= /Users/oxinabox/Documents/talks/JuliaDeepLearningMeetupLondon2019/dev/Te
nsorFlow/src/version.jl:106 =# (Core.:(@cmd))("pip3 --version"))) = pip 18.1 from /usr/
local/lib/python3.7/site-packages/pip (python 3.7)
```


after
```
-------------
Python Status
-------------
PyCall.conda = true
Trying to evaluate ENV["PYTHON"] but got error: KeyError("PYTHON")
PyCall.PYTHONHOME = /Users/oxinabox/.julia/conda/3:/Users/oxinabox/.julia/conda/3
pip --version = pip 18.1 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)

pip3 --version = pip 18.1 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
```